### PR TITLE
Finish styling color picker, including show/hide

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "font-color-contrast": "^11.1.0",
     "react": "^18.2.0",
     "react-color": "^2.19.3",
     "react-dom": "^18.2.0",

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -4,6 +4,7 @@ import ExtraPropTypes from './extraPropTypes.js'
 import CheckboxInput from './inputs/Checkbox.jsx'
 import { ChromePicker } from 'react-color';
 import IntegerInput from './inputs/Integer.jsx'
+import fontColorContrast from 'font-color-contrast';
 
 const Form = ({ formData, setFormData }) => {
   const { colorConfig, crowLength, crows, colorShift, staggerLengths, stitchPattern, showRowNumbers } = formData;
@@ -61,6 +62,15 @@ const Form = ({ formData, setFormData }) => {
               disableAlpha={true}
               onChangeComplete={(color) => setColorConfigColorValue(color, index)}
             /> 
+            <span
+              className='color-preview'
+              style={ {
+                background: colorConfig[index].color,
+                color: fontColorContrast(colorConfig[index].color),
+              }}
+            >
+              {colorConfig[index].color}
+            </span>
             <IntegerInput
               label="Length:"
               title="The number of stitches in this color segment"

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -2,11 +2,11 @@ import './Form.scss'
 import PropTypes from "prop-types";
 import ExtraPropTypes from './extraPropTypes.js'
 import CheckboxInput from './inputs/Checkbox.jsx'
-import { ChromePicker } from 'react-color';
+import { SketchPicker } from 'react-color';
 import IntegerInput from './inputs/Integer.jsx'
 import fontColorContrast from 'font-color-contrast';
 
-const Form = ({ formData, setFormData }) => {
+const Form = ({ formData, setFormData, displayColorPicker, setDisplayColorPicker }) => {
   const { colorConfig, crowLength, crows, colorShift, staggerLengths, stitchPattern, showRowNumbers } = formData;
 
   const setValue = (name, value) => {
@@ -39,6 +39,12 @@ const Form = ({ formData, setFormData }) => {
     setFormData(newFormData);
   }
 
+  const togglePickerDisplay = (index) => {
+    const newPickerDisplay = { ...displayColorPicker };
+    newPickerDisplay[index] = !(displayColorPicker[index])
+    setDisplayColorPicker(newPickerDisplay);
+  }
+
   const printColorSequenceLength = () => {
     let result = 0;
     for (const i in colorConfig) {
@@ -46,6 +52,8 @@ const Form = ({ formData, setFormData }) => {
     }
     return result;
   }
+
+  const presetColors = [...new Set(colorConfig.map((c) => c.color))];
 
   return (
     <form
@@ -55,22 +63,34 @@ const Form = ({ formData, setFormData }) => {
     >
       <div>
         {colorConfig.map((obj, index) => (
-          <div key={index + 1}>
-            <label>Color {(index + 1)}:</label>
-            <ChromePicker
-              color={colorConfig[index].color}
-              disableAlpha={true}
-              onChangeComplete={(color) => setColorConfigColorValue(color, index)}
-            /> 
+          <div className='color-segment' key={index + 1}>
+            <label>
+              Color {(index + 1)}:
+            </label>
             <span
               className='color-preview'
               style={ {
                 background: colorConfig[index].color,
                 color: fontColorContrast(colorConfig[index].color),
               }}
+              onClick={(e) => togglePickerDisplay(index)}
             >
               {colorConfig[index].color}
             </span>
+            {
+              displayColorPicker[index] ?
+                (
+                  <div className='popover'>
+                    <div className='cover' onClick={(e) => togglePickerDisplay(index)} />
+                    <SketchPicker
+                      color={colorConfig[index].color}
+                      disableAlpha={true}
+                      onChangeComplete={(color) => setColorConfigColorValue(color, index)}
+                      presetColors={presetColors}
+                    /> 
+                  </div>
+                ) : null
+            }
             <IntegerInput
               label="Length:"
               title="The number of stitches in this color segment"

--- a/src/Form.scss
+++ b/src/Form.scss
@@ -1,17 +1,17 @@
 input {
-  margin-bottom: 1em;
+  // margin-bottom: 1em;
 }
 
 .input-group {
   label {
     display: inline-block;
-    min-width: 120px;
+    // min-width: 120px;
   }
 }
 
 .number-spinner {
   display: inline-block;
-  margin-left: 1em;
+  // margin-left: 1em;
   input {
     width: 3em;
     &::-webkit-outer-spin-button,
@@ -26,11 +26,48 @@ label {
   margin-right: 0.5em;
 }
 
-.chrome-picker {
-  display: inline-block;
-  margin-bottom: 1em;
-
+.chrome-picker,
+.sketch-picker {
   label {
     margin: unset;
   }
+}
+
+.color-segment {
+  display: flex;
+  position: relative;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
+  height: 2em;
+  align-items: center;
+
+  .input-group {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.color-preview {
+  cursor: pointer;
+  padding: 0.25em 0.5em;
+  border: 1px solid black;
+  border-radius: 4px;
+  width: 4em;
+  line-height: 1.5em;
+  letter-spacing: 1px;
+}
+
+.popover {
+  position: absolute;
+  z-index: 2;
+  top: 2em;
+  left: 4.25em;
+}
+
+.cover {
+  position: fixed;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
 }

--- a/src/SwatchWithForm.jsx
+++ b/src/SwatchWithForm.jsx
@@ -14,11 +14,17 @@ function SwatchWithForm({ colorConfig, crowLength, stitchPattern, crows, colorSh
     showRowNumbers,
   })
 
+  const defaultPickerState = colorConfig.map(() => {return false});
+
+  const [displayColorPicker, setDisplayColorPicker] = useState({ defaultPickerState })
+
   return (
   <div>
     <Form
       formData={formData}
       setFormData={setFormData} 
+      displayColorPicker={displayColorPicker}
+      setDisplayColorPicker={setDisplayColorPicker}
     />
     <Swatch 
     className={formData.showRowNumbers ? "numbered" : ""}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,6 +1403,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
+font-color-contrast@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/font-color-contrast/-/font-color-contrast-11.1.0.tgz#f147720c1fd6e5e43be7aea86d247b1cdc46508b"
+  integrity sha512-PxpFaesCSsDwaciw7MF6B2thUkH7skqZlz4BzUnvapR6+Es2877q7ru/tqfsITuaraPz+TGfsOfdtU4D0qjqEw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"


### PR DESCRIPTION
- use SketchPicker instead of ChromePicker for palette functionality
- add color preview span with color as background and hex code in high-contrast text based on brightness
    - adds font-color-contrast dependency to set text contrast color
- show/hide picker on click of preview span (also hide whenever clicking outside the picker)