### PR TITLE
#58 Can drag to change color of the colorPicker without changing the color of the swatch

### DIFF
--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -2,9 +2,8 @@ import './Form.scss'
 import PropTypes from "prop-types";
 import ExtraPropTypes from './extraPropTypes.js'
 import CheckboxInput from './inputs/Checkbox.jsx'
-import { SketchPicker } from 'react-color';
+import TogglableColorPicker from './inputs/TogglableColorPicker.jsx'
 import IntegerInput from './inputs/Integer.jsx'
-import fontColorContrast from 'font-color-contrast';
 import { useState } from "react";
 
 const Form = ({ formData, setFormData }) => {
@@ -74,30 +73,13 @@ const Form = ({ formData, setFormData }) => {
             <label>
               Color {(index + 1)}:
             </label>
-            <span
-              className='color-preview'
-              style={ {
-                background: colorConfig[index].color,
-                color: fontColorContrast(colorConfig[index].color),
-              }}
-              onClick={(e) => togglePickerDisplay(index)}
-            >
-              {colorConfig[index].color}
-            </span>
-            {
-              displayColorPicker[index] ?
-                (
-                  <div className='popover'>
-                    <div className='cover' onClick={(e) => togglePickerDisplay(index)} />
-                    <SketchPicker
-                      color={colorConfig[index].color}
-                      disableAlpha={true}
-                      onChangeComplete={(color) => setColorConfigColorValue(color, index)}
-                      presetColors={presetColors}
-                    /> 
-                  </div>
-                ) : null
-            }
+            <TogglableColorPicker
+              value = {colorConfig[index].color}
+              setValue={(color) => setColorConfigColorValue(color, index)}
+              togglePicker={() => togglePickerDisplay(index)}
+              showPicker = {displayColorPicker[index]}
+              presetColors = { presetColors }
+              />
             <IntegerInput
               label="Length:"
               title="The number of stitches in this color segment"

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -5,9 +5,16 @@ import CheckboxInput from './inputs/Checkbox.jsx'
 import { SketchPicker } from 'react-color';
 import IntegerInput from './inputs/Integer.jsx'
 import fontColorContrast from 'font-color-contrast';
+import { useState } from "react";
 
-const Form = ({ formData, setFormData, displayColorPicker, setDisplayColorPicker }) => {
+const Form = ({ formData, setFormData }) => {
+
   const { colorConfig, crowLength, crows, colorShift, staggerLengths, stitchPattern, showRowNumbers } = formData;
+
+  const defaultPickerState = colorConfig.map(() => {return false});
+
+  const [displayColorPicker, setDisplayColorPicker] = useState({ defaultPickerState })
+
 
   const setValue = (name, value) => {
     const newFormData = { ...formData };

--- a/src/SwatchWithForm.jsx
+++ b/src/SwatchWithForm.jsx
@@ -14,17 +14,11 @@ function SwatchWithForm({ colorConfig, crowLength, stitchPattern, crows, colorSh
     showRowNumbers,
   })
 
-  const defaultPickerState = colorConfig.map(() => {return false});
-
-  const [displayColorPicker, setDisplayColorPicker] = useState({ defaultPickerState })
-
   return (
   <div>
     <Form
       formData={formData}
       setFormData={setFormData} 
-      displayColorPicker={displayColorPicker}
-      setDisplayColorPicker={setDisplayColorPicker}
     />
     <Swatch 
     className={formData.showRowNumbers ? "numbered" : ""}

--- a/src/inputs/TogglableColorPicker.jsx
+++ b/src/inputs/TogglableColorPicker.jsx
@@ -2,14 +2,10 @@ import { Fragment } from 'react'
 import PropTypes from "prop-types";
 import fontColorContrast from 'font-color-contrast';
 import { SketchPicker } from 'react-color';
-import { useState, useEffect } from "react";
+import { useState } from "react";
 
 const TogglableColorPicker = ({ value, setValue, presetColors, togglePicker, showPicker }) => {
-  const [pickerColor, setPickerColor] = useState({ value })
-
-  useEffect(() => {
-    setPickerColor(value)
-  }, [value])
+  const [pickerColor, setPickerColor] = useState(value)
 
   return (
     <Fragment>

--- a/src/inputs/TogglableColorPicker.jsx
+++ b/src/inputs/TogglableColorPicker.jsx
@@ -1,0 +1,45 @@
+import { Fragment } from 'react'
+import PropTypes from "prop-types";
+import fontColorContrast from 'font-color-contrast';
+import { SketchPicker } from 'react-color';
+
+const TogglableColorPicker = ({ value, setValue, presetColors, togglePicker, showPicker }) => {
+  return (
+    <Fragment>
+      <span
+        className='color-preview'
+        style={ {
+          background: value,
+          color: fontColorContrast(value),
+        }}
+        onClick={togglePicker}
+      >
+        {value}
+      </span>
+      {
+        showPicker ?
+          (
+            <div className='popover'>
+              <div className='cover' onClick={togglePicker} />
+              <SketchPicker
+                color={value}
+                disableAlpha={true}
+                onChangeComplete={setValue}
+                presetColors={presetColors}
+              /> 
+            </div>
+          ) : null
+      }
+    </Fragment>
+  )
+};
+
+TogglableColorPicker.propTypes = {
+  value: PropTypes.string, // color string
+  presetColors: PropTypes.arrayOf(PropTypes.string),
+  setValue: PropTypes.func,
+  togglePicker: PropTypes.func,
+  showPicker: PropTypes.bool
+}
+
+export default TogglableColorPicker

--- a/src/inputs/TogglableColorPicker.jsx
+++ b/src/inputs/TogglableColorPicker.jsx
@@ -2,8 +2,15 @@ import { Fragment } from 'react'
 import PropTypes from "prop-types";
 import fontColorContrast from 'font-color-contrast';
 import { SketchPicker } from 'react-color';
+import { useState, useEffect } from "react";
 
 const TogglableColorPicker = ({ value, setValue, presetColors, togglePicker, showPicker }) => {
+  const [pickerColor, setPickerColor] = useState({ value })
+
+  useEffect(() => {
+    setPickerColor(value)
+  }, [value])
+
   return (
     <Fragment>
       <span
@@ -22,8 +29,9 @@ const TogglableColorPicker = ({ value, setValue, presetColors, togglePicker, sho
             <div className='popover'>
               <div className='cover' onClick={togglePicker} />
               <SketchPicker
-                color={value}
+                color={pickerColor || value}
                 disableAlpha={true}
+                onChange={setPickerColor}
                 onChangeComplete={setValue}
                 presetColors={presetColors}
               /> 


### PR DESCRIPTION
Pull togglable color picker into its own component
move state off of swatchWithForm
Also add dragging behavior to the colorPicker to behave more like how the react-color preview behaves