### PR TITLE
use max-content for grid cols and stop fixing magic widths

### DIFF
--- a/src/Form.scss
+++ b/src/Form.scss
@@ -1,6 +1,6 @@
 form {
   display: grid;
-  grid-template-columns: 450px 1fr;
+  grid-template-columns: max-content max-content;
   grid-gap: 0.5em;
 }
 
@@ -66,7 +66,6 @@ label {
 
 .color-segment {
   display: flex;
-  width: 420px;
   position: relative;
 }
 


### PR DESCRIPTION
removes magic number and (hopefully) fixes this dumb bug with button layout on iOS
<img width="416" alt="Screenshot 2024-03-06 at 3 57 53 PM" src="https://github.com/alenia/planned-pooling/assets/284712/a69d389c-0246-46c7-930f-926acb61fe5f">
