### PR TITLE
Add footer; fixes #47

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import SwatchWithForm from './SwatchWithForm';
+import Footer from './Footer';
 import { StitchPattern, Color } from './types'
 
 const red = "#ff001d" as Color;
@@ -28,6 +29,7 @@ function App() {
   <div className="container">
     <SwatchWithForm {...config} />
   </div>
+    <Footer />
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,5 @@
 import SwatchWithForm from './SwatchWithForm';
-import Footer from './Footer';
 import { StitchPattern, Color } from './types'
-import React from 'react'
 
 const red = "#ff001d" as Color;
 const cream = "#fcf7eb" as Color;
@@ -27,10 +25,7 @@ function App() {
   }
 
   return (
-  <React.Fragment>
     <SwatchWithForm {...config} />
-    <Footer />
-  </React.Fragment>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import SwatchWithForm from './SwatchWithForm';
 import Footer from './Footer';
 import { StitchPattern, Color } from './types'
+import React from 'react'
 
 const red = "#ff001d" as Color;
 const cream = "#fcf7eb" as Color;
@@ -26,10 +27,10 @@ function App() {
   }
 
   return (
-  <div className="container">
+  <React.Fragment>
     <SwatchWithForm {...config} />
-  </div>
     <Footer />
+  </React.Fragment>
   );
 }
 

--- a/src/Footer.scss
+++ b/src/Footer.scss
@@ -1,0 +1,7 @@
+.footer {
+  margin-top: 2em;
+  display: flex;
+  gap: 2em;
+  background-color: aliceblue;
+  border-top: 1px solid #bbbbbb;
+}

--- a/src/Footer.scss
+++ b/src/Footer.scss
@@ -1,5 +1,4 @@
 .footer {
-  margin-top: 2em;
   display: flex;
   gap: 2em;
   background-color: aliceblue;

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -1,0 +1,16 @@
+import './Footer.scss'
+
+function Footer() {
+  return (
+  <div className="footer container">
+    <div>
+      Contact: <a href="mailto:info@frog2tog.com">info@frog2tog.com</a>
+    </div>
+    <div>
+      More: <a href="http://frog2tog.com">frog2tog.com</a>
+    </div>
+  </div>
+  );
+}
+
+export default Footer;

--- a/src/Swatch.scss
+++ b/src/Swatch.scss
@@ -29,9 +29,11 @@ version of preview. Hopefully there will be a test of this diff at some point*/
 /*Shared swatch styling including row-reverse layout*/
 .swatch {
   margin: 5px 0;
+  padding-bottom: 2em;
   width: fit-content;
   display: flex;
   flex-direction: column-reverse;
+
   .crow {
     display: flex;
     flex-direction: row;

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -27,7 +27,7 @@ function SwatchWithForm(
   })
 
   return (
-  <div className='container'>
+  <div>
     <Form
       formData={formData}
       setFormData={setFormData} 

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -27,7 +27,7 @@ function SwatchWithForm(
   })
 
   return (
-  <div>
+  <div className='container'>
     <Form
       formData={formData}
       setFormData={setFormData} 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,6 @@
-#root {
-  margin: 20px;
+body {
+  margin: 0;
+}
+.container {
+  padding: 30px;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,6 +1,12 @@
 body {
   margin: 0;
 }
+
+#root {
+  display: grid;
+  min-height: 100dvh;
+}
+
 .container {
   padding: 30px;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,5 +8,5 @@ body {
 }
 
 .container {
-  padding: 30px;
+  padding: 24px;
 }

--- a/src/projects/Doodle.tsx
+++ b/src/projects/Doodle.tsx
@@ -28,7 +28,7 @@ function Doodle() {
   }
 
   return (
-  <div className="container">
+  <div>
     <p>This displays what the Zen Garden 500g ball looks like in Jasmine Stitch</p>
     <SwatchWithForm {...config} />
   </div>

--- a/src/projects/LogoOption.tsx
+++ b/src/projects/LogoOption.tsx
@@ -27,9 +27,7 @@ function LogoOption() {
   }
 
   return (
-  <div className="container">
     <SwatchWithForm {...config} />
-  </div>
   );
 }
 

--- a/src/wrapper.tsx
+++ b/src/wrapper.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import Footer from './Footer';
 import Preview from './projects/Preview'
 import Sunflower from './projects/Sunflower'
 import Doodle from './projects/Doodle'
@@ -26,6 +27,9 @@ const Main = router();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <Main />
+    <div className="container">
+      <Main />
+    </div>
+    <Footer />
   </React.StrictMode>,
 )


### PR DESCRIPTION
- top border color matches fieldset border color
- basic background color for clarity (can be changed later)
- refactors containing divs 
  - allow footer to be edge-to-edge
  - remove duplicate divs and .container uses
- works on all endpoints of the app
- works on iPad
- NOTE: display of footer on iPhone in landscape has extra spacing on left/right but phone display is kinda janky anyway and it's not a priority to fix

When swatch does not fill height:
<img width="1296" alt="Screenshot 2024-03-07 at 11 08 35 AM" src="https://github.com/alenia/planned-pooling/assets/284712/80a87798-f563-4440-a947-42fc3b4effe5">

When swatch does fill height:
<img width="1349" alt="Screenshot 2024-03-07 at 11 09 16 AM" src="https://github.com/alenia/planned-pooling/assets/284712/b70a7259-d8e8-46a1-a7fc-4160f551f313">

iPad, `/doodle` endpoint:
![Simulator Screenshot - iPad Air (5th generation) - 2024-03-07 at 11 21 12](https://github.com/alenia/planned-pooling/assets/284712/31606129-76e3-4b37-8a9a-f5faade16c4e)