### PR TITLE
Fix display issue of spinners on iPhone

### DIFF
--- a/src/Form.scss
+++ b/src/Form.scss
@@ -42,7 +42,7 @@ input[type=checkbox] {
 }
 
 .number-spinner {
-  display: inline-block;
+  display: flex;
   input {
     width: 3em;
     &::-webkit-outer-spin-button,


### PR DESCRIPTION
The iPhone still scrolls side to side but that usability is ok because I zoom it out anyway to look at the actual swatch.
