### PR TITLE
add margin between unwrapped input and label

### DIFF
--- a/src/Form.scss
+++ b/src/Form.scss
@@ -57,6 +57,10 @@ label {
   margin-right: 0.5em;
 }
 
+.checkbox-container.unwrapped-input {
+  label { margin-left: 0.5em; }
+}
+
 .chrome-picker,
 .sketch-picker {
   label {

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -159,7 +159,7 @@ const Form = (
       </fieldset>
 
       <CheckboxInput
-        className="checkbox-container"
+        className="checkbox-container unwrapped-input"
         label="Show Row Numbers"
         title="Display row numbers at the beginning of each row."
         name="showRowNumbers"


### PR DESCRIPTION
Before:
<img width="237" alt="Screenshot 2024-03-07 at 11 49 47 AM" src="https://github.com/alenia/planned-pooling/assets/284712/5f574435-440a-48dc-bebe-8ab56baa468a">

After:
<img width="227" alt="Screenshot 2024-03-07 at 11 49 54 AM" src="https://github.com/alenia/planned-pooling/assets/284712/47d3b4f5-dffc-4fa5-946d-59b2c72d9da2">
