### PR TITLE
Update URL Query Params when form values change and read initial values from the URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^18.2.0",
     "react-color": "^2.19.3",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
     "sass": "^1.62.1",
     "serve": "^14.2.1",
     "typescript": "^5.3.3",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,10 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from "react-router-dom";
 import App from './App'
 
 describe('App', () => {
   it('renders the App component with a swatch in it', () => {
-    render(<App />)
+    render(
+      <MemoryRouter >
+        <App />
+      </MemoryRouter>
+    )
     expect(screen.getAllByTestId("swatch").length).toEqual(1)
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import SwatchWithForm from './SwatchWithForm';
 import { StitchPattern, Color } from './types'
 import { useState, useEffect } from "react";
 import { useSearchParams } from 'react-router-dom';
-import { URLSearchParamsFromSwatchParams, sanitizeSearchParamInputs } from './searchHelpers';
+import { URLSearchParamsFromSwatchConfig, sanitizeSearchParamInputs } from './searchHelpers';
 
 const red = "#ff001d" as Color;
 const cream = "#fcf7eb" as Color;
@@ -11,7 +11,7 @@ const navy = "#0e0e66" as Color;
 
 function App() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [swatchParams, setSwatchParams] = useState({
+  const [swatchConfig, setSwatchConfig] = useState({
     colorConfig: sanitizeSearchParamInputs.colorConfig(searchParams) || [
       {color: navy, length: 3},
       {color: red, length: 3},
@@ -29,13 +29,13 @@ function App() {
   })
 
   useEffect(() => {
-    const newSearchParams = URLSearchParamsFromSwatchParams(swatchParams)
+    const newSearchParams = URLSearchParamsFromSwatchConfig(swatchConfig)
 
     setSearchParams(newSearchParams)
-  }, [swatchParams, setSearchParams])
+  }, [swatchConfig, setSearchParams])
 
   return (
-    <SwatchWithForm swatchParams={swatchParams} setSwatchParams={setSwatchParams} />
+    <SwatchWithForm swatchConfig={swatchConfig} setSwatchConfig={setSwatchConfig} />
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import SwatchWithForm from './SwatchWithForm';
 import { StitchPattern, Color } from './types'
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams } from 'react-router-dom';
+import { URLSearchParamsFromSwatchParams, sanitizeSearchParamInputs } from './searchHelpers';
 
 const red = "#ff001d" as Color;
 const cream = "#fcf7eb" as Color;
@@ -8,8 +10,9 @@ const ltblue = "#8dd0f2" as Color;
 const navy = "#0e0e66" as Color;
 
 function App() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [swatchParams, setSwatchParams] = useState({
-    colorConfig: [
+    colorConfig: sanitizeSearchParamInputs.colorConfig(searchParams) || [
       {color: navy, length: 3},
       {color: red, length: 3},
       {color: navy, length: 3},
@@ -17,13 +20,19 @@ function App() {
       {color: cream, length: 5},
       {color: ltblue, length: 2},
     ],
-    crowLength: 18,
-    crows: 40,
-    colorShift: 0,
+    crowLength: sanitizeSearchParamInputs.crowLength(searchParams) || 18, //Note: explicitly ok not saving zero from search params here
+    crows: sanitizeSearchParamInputs.crows(searchParams) || 40, //Note: explicitly ok not pulling zero from search params here
+    colorShift: sanitizeSearchParamInputs.colorShift(searchParams) || 0,
     staggerLengths: false,
     stitchPattern: StitchPattern.moss,
     showRowNumbers: false
   })
+
+  useEffect(() => {
+    const newSearchParams = URLSearchParamsFromSwatchParams(swatchParams)
+
+    setSearchParams(newSearchParams)
+  }, [swatchParams, setSearchParams])
 
   return (
     <SwatchWithForm swatchParams={swatchParams} setSwatchParams={setSwatchParams} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,8 @@ function App() {
     crowLength: sanitizeSearchParamInputs.crowLength(searchParams) || 18, //Note: explicitly ok not saving zero from search params here
     crows: sanitizeSearchParamInputs.crows(searchParams) || 40, //Note: explicitly ok not pulling zero from search params here
     colorShift: sanitizeSearchParamInputs.colorShift(searchParams) || 0,
-    staggerLengths: false,
-    stitchPattern: StitchPattern.moss,
+    staggerLengths: sanitizeSearchParamInputs.staggerLengths(searchParams),
+    stitchPattern: sanitizeSearchParamInputs.stitchPattern(searchParams) || StitchPattern.moss,
     showRowNumbers: false
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import SwatchWithForm from './SwatchWithForm';
 import { StitchPattern, Color } from './types'
+import { useState } from "react";
 
 const red = "#ff001d" as Color;
 const cream = "#fcf7eb" as Color;
@@ -7,7 +8,7 @@ const ltblue = "#8dd0f2" as Color;
 const navy = "#0e0e66" as Color;
 
 function App() {
-  const config = {
+  const [swatchParams, setSwatchParams] = useState({
     colorConfig: [
       {color: navy, length: 3},
       {color: red, length: 3},
@@ -22,10 +23,10 @@ function App() {
     staggerLengths: false,
     stitchPattern: StitchPattern.moss,
     showRowNumbers: false
-  }
+  })
 
   return (
-    <SwatchWithForm {...config} />
+    <SwatchWithForm swatchParams={swatchParams} setSwatchParams={setSwatchParams} />
   );
 }
 

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -1,40 +1,17 @@
 import Swatch from './Swatch';
 import Form from './Form';
-import { useState } from "react";
-import { StitchPattern, ColorConfigArray } from './types'
+import { SwatchParams } from './types'
 
-function SwatchWithForm(
-  { colorConfig, crowLength, stitchPattern, crows, colorShift, staggerLengths, showRowNumbers = false}
-  : {
-    colorConfig: ColorConfigArray,
-    crowLength: number,
-    stitchPattern: StitchPattern,
-    crows: number,
-    colorShift: number,
-    staggerLengths: boolean,
-    showRowNumbers: boolean
-  }
-
-) {
-  const [formData, setFormData] = useState({
-    colorConfig,
-    crowLength,
-    crows,
-    colorShift,
-    staggerLengths,
-    stitchPattern,
-    showRowNumbers,
-  })
-
+function SwatchWithForm({swatchParams, setSwatchParams}  : { swatchParams: SwatchParams, setSwatchParams: (arg0: SwatchParams) => void}) {
   return (
   <div>
     <Form
-      formData={formData}
-      setFormData={setFormData} 
+      formData={swatchParams}
+      setFormData={setSwatchParams} 
     />
     <Swatch 
-    className={formData.showRowNumbers ? "numbered" : ""}
-    {...formData} />
+    className={swatchParams.showRowNumbers ? "numbered" : ""}
+    {...swatchParams} />
   </div>
   );
 }

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -1,17 +1,17 @@
 import Swatch from './Swatch';
 import Form from './Form';
-import { SwatchParams } from './types'
+import { SwatchConfig } from './types'
 
-function SwatchWithForm({swatchParams, setSwatchParams}  : { swatchParams: SwatchParams, setSwatchParams: (arg0: SwatchParams) => void}) {
+function SwatchWithForm({swatchConfig, setSwatchConfig}  : { swatchConfig: SwatchConfig, setSwatchConfig: (arg0: SwatchConfig) => void}) {
   return (
   <div>
     <Form
-      formData={swatchParams}
-      setFormData={setSwatchParams} 
+      formData={swatchConfig}
+      setFormData={setSwatchConfig}
     />
     <Swatch 
-    className={swatchParams.showRowNumbers ? "numbered" : ""}
-    {...swatchParams} />
+    className={swatchConfig.showRowNumbers ? "numbered" : ""}
+    {...swatchConfig} />
   </div>
   );
 }

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { nextStitchColorByIndex } from './color'
+import { nextStitchColorByIndex, isStringAColor } from './color'
 import { ColorConfigArray } from './types'
 
 describe('nextStitchByColorIndex', () => {
@@ -43,5 +43,19 @@ describe('nextStitchByColorIndex', () => {
     expect(nextStitchColorByIndex(9, config, {colorShift: 3})).toBe("#0f0")
     expect(nextStitchColorByIndex(10, config, {colorShift: 3})).toBe("#0f0")
     expect(nextStitchColorByIndex(11, config, {colorShift: 3})).toBe("#00f")
+  })
+})
+
+describe('isStringAColor', () => {
+  it('tells you whether or not a string is a hex color', () => {
+    expect(isStringAColor('#fff')).toBe(true)
+    expect(isStringAColor('#FFF')).toBe(true)
+    expect(isStringAColor('#000')).toBe(true)
+    expect(isStringAColor('#012345')).toBe(true)
+    expect(isStringAColor('#ffffff')).toBe(true)
+    expect(isStringAColor('#FFFFFF')).toBe(true)
+    expect(isStringAColor('#gggggg')).toBe(false)
+    expect(isStringAColor('ffffff')).toBe(false)
+    expect(isStringAColor('#ffff')).toBe(false)
   })
 })

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,5 +1,10 @@
 import { Color, ColorConfig, ColorConfigArray } from './types'
+
 export function nextStitchColorByIndex(i : number, colorConfig : ColorConfigArray, { colorShift } = { colorShift: 0 } ):Color {
   const flatColorSequenceArray = colorConfig.reduce((ary : Array<Color>, conf: ColorConfig) : Array<Color> => ary.concat(new Array(conf.length).fill(conf.color)), []);
   return flatColorSequenceArray[(i + colorShift) % flatColorSequenceArray.length];
+}
+
+export function isStringAColor(s: string) : boolean {
+  return /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(s);
 }

--- a/src/inputs/Checkbox.tsx
+++ b/src/inputs/Checkbox.tsx
@@ -13,7 +13,7 @@ function Checkbox(
           }
           name={name}
           id={name}
-          value={value.toString()} // Typescript wants me to cast the boolean to a string myself
+          checked={value}
         />
         <label htmlFor={name} title={title}>
         {label}

--- a/src/projects/Doodle.test.tsx
+++ b/src/projects/Doodle.test.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import Doodle from './Doodle'
+
+describe('Doodle', () => {
+  it('renders the component with a swatch in it', () => {
+    render(<Doodle />)
+    expect(screen.getAllByTestId("swatch").length).toEqual(1)
+  })
+})

--- a/src/projects/Doodle.tsx
+++ b/src/projects/Doodle.tsx
@@ -11,7 +11,7 @@ const orange = "#d66127" as Color;
 const yellow = "#f5b638" as Color;
 
 function Doodle() {
-  const [swatchParams, setSwatchParams] = useState({
+  const [swatchConfig, setSwatchConfig] = useState({
     colorConfig: [
       {color: dark, length: 1},
       {color: grey, length: 2},
@@ -31,7 +31,7 @@ function Doodle() {
   return (
   <div>
     <p>This displays what the Zen Garden 500g ball looks like in Jasmine Stitch</p>
-    <SwatchWithForm swatchParams={swatchParams} setSwatchParams={setSwatchParams} />
+    <SwatchWithForm swatchConfig={swatchConfig} setSwatchConfig={setSwatchConfig} />
   </div>
   );
 }

--- a/src/projects/Doodle.tsx
+++ b/src/projects/Doodle.tsx
@@ -3,6 +3,7 @@
 //But for now I'll do this
 import SwatchWithForm from '../SwatchWithForm';
 import { StitchPattern, Color } from '../types'
+import { useState } from "react";
 
 const grey = "#4f4d4d" as Color;
 const dark = "#30221a" as Color;
@@ -10,7 +11,7 @@ const orange = "#d66127" as Color;
 const yellow = "#f5b638" as Color;
 
 function Doodle() {
-  const config = {
+  const [swatchParams, setSwatchParams] = useState({
     colorConfig: [
       {color: dark, length: 1},
       {color: grey, length: 2},
@@ -25,12 +26,12 @@ function Doodle() {
     staggerLengths: false,
     stitchPattern: StitchPattern.jasmine,
     showRowNumbers: false,
-  }
+  })
 
   return (
   <div>
     <p>This displays what the Zen Garden 500g ball looks like in Jasmine Stitch</p>
-    <SwatchWithForm {...config} />
+    <SwatchWithForm swatchParams={swatchParams} setSwatchParams={setSwatchParams} />
   </div>
   );
 }

--- a/src/projects/LogoOption.test.tsx
+++ b/src/projects/LogoOption.test.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import LogoOption from './LogoOption'
+
+describe('LogoOption', () => {
+  it('renders the component with a swatch in it', () => {
+    render(<LogoOption />)
+    expect(screen.getAllByTestId("swatch").length).toEqual(1)
+  })
+})

--- a/src/projects/LogoOption.tsx
+++ b/src/projects/LogoOption.tsx
@@ -11,7 +11,7 @@ const cream = "#fefbec" as Color;
 const lightTeal = "#70afb7" as Color;
 
 function LogoOption() {
-  const [swatchParams, setSwatchParams] = useState({
+  const [swatchConfig, setSwatchConfig] = useState({
     colorConfig: [
       {color: coral, length: 2},
       {color: teal, length: 5},
@@ -28,7 +28,7 @@ function LogoOption() {
   })
 
   return (
-    <SwatchWithForm swatchParams={swatchParams} setSwatchParams={setSwatchParams} />
+    <SwatchWithForm swatchConfig={swatchConfig} setSwatchConfig={setSwatchConfig} />
   );
 }
 

--- a/src/projects/LogoOption.tsx
+++ b/src/projects/LogoOption.tsx
@@ -3,6 +3,7 @@
 //But for now I'll do this
 import SwatchWithForm from '../SwatchWithForm';
 import { StitchPattern, Color } from '../types'
+import { useState } from "react";
 
 const coral = "#e26654" as Color;
 const teal = "#317781" as Color;
@@ -10,7 +11,7 @@ const cream = "#fefbec" as Color;
 const lightTeal = "#70afb7" as Color;
 
 function LogoOption() {
-  const config = {
+  const [swatchParams, setSwatchParams] = useState({
     colorConfig: [
       {color: coral, length: 2},
       {color: teal, length: 5},
@@ -24,10 +25,10 @@ function LogoOption() {
     staggerLengths: false,
     stitchPattern: StitchPattern.moss,
     showRowNumbers: false,
-  }
+  })
 
   return (
-    <SwatchWithForm {...config} />
+    <SwatchWithForm swatchParams={swatchParams} setSwatchParams={setSwatchParams} />
   );
 }
 

--- a/src/projects/Preview.test.tsx
+++ b/src/projects/Preview.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import Preview from './Preview'
+
+describe('Preview', () => {
+  it('renders the component with a swatch in it', () => {
+    render(<Preview />)
+    expect(screen.getAllByTestId("swatch").length).toBeGreaterThan(1)
+  })
+})
+

--- a/src/projects/Sunflower.test.tsx
+++ b/src/projects/Sunflower.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import Sunflower from './Sunflower'
+
+describe('Sunflower', () => {
+  it('renders the component with a swatch in it', () => {
+    render(<Sunflower />)
+    expect(screen.getAllByTestId("swatch").length).toBeGreaterThan(1)
+  })
+})
+

--- a/src/searchHelpers.test.ts
+++ b/src/searchHelpers.test.ts
@@ -51,8 +51,8 @@ describe('sanitizeSearchParamInputs', () => {
       {color: '#f00', length: 3},
       {color: '#0f0', length: 2},
     ])
-    //expect(sanitizeSearchParamInputs.stitchPattern(searchParams)).toEqual(StitchPattern.moss)
-    //expect(sanitizeSearchParamInputs.staggerLengths(searchParams)).toEqual(true)
+    expect(sanitizeSearchParamInputs.stitchPattern(searchParams)).toEqual(StitchPattern.moss)
+    expect(sanitizeSearchParamInputs.staggerLengths(searchParams)).toEqual(true)
   })
 
   it('only returns crowLength iff it is a number', () => {
@@ -97,5 +97,14 @@ describe('sanitizeSearchParamInputs', () => {
     expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(notEnoughColors))).toEqual(false)
     expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(colorsAreNotColors))).toEqual(false)
     expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(lengthsAreNotNumbers))).toEqual(false)
+  })
+  it('returns stagger lengths iff it is true', () => {
+    expect(sanitizeSearchParamInputs.staggerLengths(new URLSearchParams('?staggerLengths=true'))).toEqual(true)
+    expect(sanitizeSearchParamInputs.staggerLengths(new URLSearchParams('?staggerLengths=banana'))).toEqual(false)
+    expect(sanitizeSearchParamInputs.staggerLengths(new URLSearchParams('?staggerLengths=false'))).toEqual(false)
+  })
+  it('returns stitch patterns', () => {
+    expect(sanitizeSearchParamInputs.stitchPattern(new URLSearchParams('?stitchPattern=stacked'))).toEqual(StitchPattern.stacked)
+    expect(sanitizeSearchParamInputs.stitchPattern(new URLSearchParams('?stitchPattern=banana'))).toEqual(false)
   })
 })

--- a/src/searchHelpers.test.ts
+++ b/src/searchHelpers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { URLSearchParamsFromSwatchParams, sanitizeSearchParamInputs } from './searchHelpers'
+import { StitchPattern, SwatchParams } from './types'
+
+describe('URLSearchParamsFromSwatchParams', () => {
+  it('includes all the relevent info in the URL params', () => {
+    const swatchParams = {
+      colorConfig: [
+        {color: '#f00', length: 3},
+        {color: '#0f0', length: 2},
+      ],
+      crowLength: 18,
+      crows: 40,
+      colorShift: 5,
+      staggerLengths: false,
+      stitchPattern: StitchPattern.moss,
+      showRowNumbers: false
+    } as SwatchParams
+
+    const searchParams = URLSearchParamsFromSwatchParams(swatchParams)
+    expect(searchParams.get('stitchPattern')).toEqual('moss')
+    expect(searchParams.get('stitchesPerRow')).toEqual("18")
+    expect(searchParams.get('rows')).toEqual("40")
+    expect(searchParams.get('colorShift')).toEqual("5")
+    expect(searchParams.get('staggerLengths')).toEqual("false")
+    expect(searchParams.get('colors')).toEqual('#f00,#0f0')
+    expect(searchParams.get('colorLengths')).toEqual('3,2')
+  })
+})
+
+describe('sanitizeSearchParamInputs', () => {
+  it('works properly with the parameterized inputs', () => {
+    const swatchParams = {
+      colorConfig: [
+        {color: '#f00', length: 3},
+        {color: '#0f0', length: 2},
+      ],
+      crowLength: 18,
+      crows: 40,
+      colorShift: 5,
+      staggerLengths: true,
+      stitchPattern: StitchPattern.moss,
+      showRowNumbers: false
+    } as SwatchParams
+
+    const searchParams = URLSearchParamsFromSwatchParams(swatchParams)
+    expect(sanitizeSearchParamInputs.crowLength(searchParams)).toEqual(18)
+    expect(sanitizeSearchParamInputs.crows(searchParams)).toEqual(40)
+    expect(sanitizeSearchParamInputs.colorShift(searchParams)).toEqual(5)
+    expect(sanitizeSearchParamInputs.colorConfig(searchParams)).toEqual([
+      {color: '#f00', length: 3},
+      {color: '#0f0', length: 2},
+    ])
+    //expect(sanitizeSearchParamInputs.stitchPattern(searchParams)).toEqual(StitchPattern.moss)
+    //expect(sanitizeSearchParamInputs.staggerLengths(searchParams)).toEqual(true)
+  })
+
+  it('only returns crowLength iff it is a number', () => {
+    expect(sanitizeSearchParamInputs.crowLength(new URLSearchParams('?stitchesPerRow=20'))).toEqual(20)
+    expect(sanitizeSearchParamInputs.crowLength(new URLSearchParams('?stitchesPerRow=0'))).toEqual(0)
+    expect(sanitizeSearchParamInputs.crowLength(new URLSearchParams('?stitchesPerRow=foo'))).toEqual(NaN)
+    expect(sanitizeSearchParamInputs.crowLength(new URLSearchParams('?notHere=4'))).toEqual(NaN)
+    //TODO: Don't allow negative numbers
+  })
+  it('only returns crows iff it is a number', () => {
+    expect(sanitizeSearchParamInputs.crows(new URLSearchParams('?rows=20'))).toEqual(20)
+    expect(sanitizeSearchParamInputs.crows(new URLSearchParams('?rows=0'))).toEqual(0)
+    expect(sanitizeSearchParamInputs.crows(new URLSearchParams('?rows=foo'))).toEqual(NaN)
+    expect(sanitizeSearchParamInputs.crows(new URLSearchParams('?notHere=4'))).toEqual(NaN)
+  })
+  it('only returns colorShift iff it is a number', () => {
+    expect(sanitizeSearchParamInputs.colorShift(new URLSearchParams('?colorShift=20'))).toEqual(20)
+    expect(sanitizeSearchParamInputs.colorShift(new URLSearchParams('?colorShift=0'))).toEqual(0)
+    expect(sanitizeSearchParamInputs.colorShift(new URLSearchParams('?colorShift=foo'))).toEqual(NaN)
+    expect(sanitizeSearchParamInputs.colorShift(new URLSearchParams('?notHere=4'))).toEqual(NaN)
+    //TODO: Don't allow negative numbers
+  })
+  it('returns colorConfig iff properly formatted', () => {
+    const goodParams = '?colors=%230e0e66%2C%23ff001d%2C%230e0e66%2C%238dd0f2%2C%23fcf7eb%2C%238dd0f2&colorLengths=3%2C3%2C3%2C2%2C5%2C2'
+    const notEnoughLengths = '?colors=%230e0e66%2C%23ff001d%2C%230e0e66%2C%238dd0f2%2C%23fcf7eb%2C%238dd0f2&colorLengths=3%2C3%2C3%2C2%2C5'
+    const notEnoughColors = '?colors=%230e0e66%2C%23ff001d%2C%230e0e66%2C%238dd0f2%2C%23fcf7eb&colorLengths=3%2C3%2C3%2C2%2C5%2C2'
+    const colorsAreNotColors = '?colors=%230e0e66%2C%23ff001d%2C%230e0e66%2C%238dd0f2%2Cwhoops&colorLengths=3%2C3%2C3%2C2%2C5%2C2'
+    const lengthsAreNotNumbers = '?colors=%230e0e66%2C%23ff001d%2C%230e0e66%2C%238dd0f2%2C%23fcf7eb%2C%238dd0f2&colorLengths=3%2C3%2C3%2C2%2C5%2Cfour'
+    const missingColors = '?colorLengths=3%2C3%2C3%2C2%2C5'
+    const missingLengths = '?colors=%230e0e66%2C%23ff001d%2C%230e0e66%2C%238dd0f2%2C%23fcf7eb%2C%238dd0f2'
+    expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(goodParams))).toEqual([
+      {color: "#0e0e66", length: 3},
+      {color: "#ff001d", length: 3},
+      {color: "#0e0e66", length: 3},
+      {color: "#8dd0f2", length: 2},
+      {color: "#fcf7eb", length: 5},
+      {color: "#8dd0f2", length: 2},
+    ])
+    expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(missingColors))).toEqual(false)
+    expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(missingLengths))).toEqual(false)
+    expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(notEnoughLengths))).toEqual(false)
+    expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(notEnoughColors))).toEqual(false)
+    expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(colorsAreNotColors))).toEqual(false)
+    expect(sanitizeSearchParamInputs.colorConfig(new URLSearchParams(lengthsAreNotNumbers))).toEqual(false)
+  })
+})

--- a/src/searchHelpers.test.ts
+++ b/src/searchHelpers.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { URLSearchParamsFromSwatchParams, sanitizeSearchParamInputs } from './searchHelpers'
-import { StitchPattern, SwatchParams } from './types'
+import { URLSearchParamsFromSwatchConfig, sanitizeSearchParamInputs } from './searchHelpers'
+import { StitchPattern, SwatchConfig } from './types'
 
-describe('URLSearchParamsFromSwatchParams', () => {
+describe('URLSearchParamsFromSwatchConfig', () => {
   it('includes all the relevent info in the URL params', () => {
-    const swatchParams = {
+    const swatchConfig = {
       colorConfig: [
         {color: '#f00', length: 3},
         {color: '#0f0', length: 2},
@@ -15,9 +15,9 @@ describe('URLSearchParamsFromSwatchParams', () => {
       staggerLengths: false,
       stitchPattern: StitchPattern.moss,
       showRowNumbers: false
-    } as SwatchParams
+    } as SwatchConfig
 
-    const searchParams = URLSearchParamsFromSwatchParams(swatchParams)
+    const searchParams = URLSearchParamsFromSwatchConfig(swatchConfig)
     expect(searchParams.get('stitchPattern')).toEqual('moss')
     expect(searchParams.get('stitchesPerRow')).toEqual("18")
     expect(searchParams.get('rows')).toEqual("40")
@@ -30,7 +30,7 @@ describe('URLSearchParamsFromSwatchParams', () => {
 
 describe('sanitizeSearchParamInputs', () => {
   it('works properly with the parameterized inputs', () => {
-    const swatchParams = {
+    const swatchConfig = {
       colorConfig: [
         {color: '#f00', length: 3},
         {color: '#0f0', length: 2},
@@ -41,9 +41,9 @@ describe('sanitizeSearchParamInputs', () => {
       staggerLengths: true,
       stitchPattern: StitchPattern.moss,
       showRowNumbers: false
-    } as SwatchParams
+    } as SwatchConfig
 
-    const searchParams = URLSearchParamsFromSwatchParams(swatchParams)
+    const searchParams = URLSearchParamsFromSwatchConfig(swatchConfig)
     expect(sanitizeSearchParamInputs.crowLength(searchParams)).toEqual(18)
     expect(sanitizeSearchParamInputs.crows(searchParams)).toEqual(40)
     expect(sanitizeSearchParamInputs.colorShift(searchParams)).toEqual(5)

--- a/src/searchHelpers.ts
+++ b/src/searchHelpers.ts
@@ -1,4 +1,4 @@
-import { SwatchParams, ColorConfigArray, Color } from './types'
+import { SwatchParams, ColorConfigArray, Color, StitchPattern } from './types'
 import { isStringAColor } from './color'
 
 export function URLSearchParamsFromSwatchParams(swatchParams : SwatchParams) : URLSearchParams {
@@ -46,4 +46,13 @@ export const sanitizeSearchParamInputs = {
   crowLength: numberParserForParam('stitchesPerRow'),
   crows: numberParserForParam('rows'),
   colorShift: numberParserForParam('colorShift'),
+  staggerLengths: (searchParams: URLSearchParams) : boolean => {
+    return searchParams.get('staggerLengths') === 'true'
+  },
+  stitchPattern: (searchParams: URLSearchParams) : StitchPattern | false => {
+    const stitchPatternParam = searchParams.get('stitchPattern')
+    if(!stitchPatternParam) { return false }
+    //return StitchPattern[stitchPatternParam] || false // can't do this because typescript doesn't like it
+    return Object.values<string>(StitchPattern).includes(stitchPatternParam) ? stitchPatternParam as StitchPattern : false
+  },
 }

--- a/src/searchHelpers.ts
+++ b/src/searchHelpers.ts
@@ -1,16 +1,16 @@
-import { SwatchParams, ColorConfigArray, Color, StitchPattern } from './types'
+import { SwatchConfig, ColorConfigArray, Color, StitchPattern } from './types'
 import { isStringAColor } from './color'
 
-export function URLSearchParamsFromSwatchParams(swatchParams : SwatchParams) : URLSearchParams {
+export function URLSearchParamsFromSwatchConfig(swatchConfig : SwatchConfig) : URLSearchParams {
   // renamed crows because it's an external facing API
   const flattenedParams = {
-    stitchesPerRow: swatchParams.crowLength.toString(),
-    rows: swatchParams.crows.toString(),
-    colorShift: swatchParams.colorShift.toString(),
-    staggerLengths: swatchParams.staggerLengths.toString(),
-    stitchPattern: swatchParams.stitchPattern.toString(),
-    colors: swatchParams.colorConfig.map(({color}) => color).toString(),
-    colorLengths: swatchParams.colorConfig.map(({length}) => length).toString()
+    stitchesPerRow: swatchConfig.crowLength.toString(),
+    rows: swatchConfig.crows.toString(),
+    colorShift: swatchConfig.colorShift.toString(),
+    staggerLengths: swatchConfig.staggerLengths.toString(),
+    stitchPattern: swatchConfig.stitchPattern.toString(),
+    colors: swatchConfig.colorConfig.map(({color}) => color).toString(),
+    colorLengths: swatchConfig.colorConfig.map(({length}) => length).toString()
   }
   return new URLSearchParams(flattenedParams);
 }

--- a/src/searchHelpers.ts
+++ b/src/searchHelpers.ts
@@ -1,0 +1,49 @@
+import { SwatchParams, ColorConfigArray, Color } from './types'
+import { isStringAColor } from './color'
+
+export function URLSearchParamsFromSwatchParams(swatchParams : SwatchParams) : URLSearchParams {
+  // renamed crows because it's an external facing API
+  const flattenedParams = {
+    stitchesPerRow: swatchParams.crowLength.toString(),
+    rows: swatchParams.crows.toString(),
+    colorShift: swatchParams.colorShift.toString(),
+    staggerLengths: swatchParams.staggerLengths.toString(),
+    stitchPattern: swatchParams.stitchPattern.toString(),
+    colors: swatchParams.colorConfig.map(({color}) => color).toString(),
+    colorLengths: swatchParams.colorConfig.map(({length}) => length).toString()
+  }
+  return new URLSearchParams(flattenedParams);
+}
+
+function numberParserForParam (paramName : string) : (searchParams: URLSearchParams) => (number) {
+  return (searchParams) => {
+    const param = searchParams.get(paramName) || ''
+    return parseInt(param)
+  }
+}
+
+export const sanitizeSearchParamInputs = {
+  colorConfig: (searchParams : URLSearchParams) : ColorConfigArray | false => {
+    const colorsString = searchParams.get('colors')
+    const colorLengthsString = searchParams.get('colorLengths')
+    if(!colorsString || !colorLengthsString) { return false }
+
+    const colorsArray = colorsString.split(',')
+    const colorLengths = colorLengthsString.split(',').map((l) => parseInt(l))
+
+    if(colorsArray.length !== colorLengths.length) {
+      return false
+    }
+    if(colorsArray.some((c) => !isStringAColor(c))) {
+      return false
+    }
+    if(colorLengths.some((v) => isNaN(v))) {
+      return false
+    }
+
+    return colorsArray.map((color, index) => ({ color: color as Color, length: colorLengths[index] }))
+  },
+  crowLength: numberParserForParam('stitchesPerRow'),
+  crows: numberParserForParam('rows'),
+  colorShift: numberParserForParam('colorShift'),
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,3 +20,13 @@ export type ColorConfig = {
 }
 
 export type ColorConfigArray = Array<ColorConfig>
+
+export type SwatchParams = {
+    colorConfig: ColorConfigArray,
+    crowLength: number,
+    stitchPattern: StitchPattern,
+    crows: number,
+    colorShift: number,
+    staggerLengths: boolean,
+    showRowNumbers: boolean
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type ColorConfig = {
 
 export type ColorConfigArray = Array<ColorConfig>
 
-export type SwatchParams = {
+export type SwatchConfig = {
     colorConfig: ColorConfigArray,
     crowLength: number,
     stitchPattern: StitchPattern,

--- a/src/wrapper.tsx
+++ b/src/wrapper.tsx
@@ -7,28 +7,38 @@ import Sunflower from './projects/Sunflower'
 import Doodle from './projects/Doodle'
 import LogoOption from './projects/LogoOption'
 import './index.scss'
+import {
+  createBrowserRouter,
+  RouterProvider
+} from "react-router-dom"
 
-const router = () => {
-  switch (window.location.pathname) {
-    case "/preview":
-      return Preview;
-    case "/sunflower":
-      return Sunflower;
-    case "/doodle":
-      return Doodle;
-    case "/branding-ideas":
-      return LogoOption;
-    default:
-    return App;
+const router = createBrowserRouter([
+  {
+    path: "/preview",
+    element: <Preview/>
+  },
+  {
+    path: "/sunflower",
+    element: <Sunflower/>
+  },
+  {
+    path: "/doodle",
+    element: <Doodle/>
+  },
+  {
+    path: "/branding-ideas",
+    element: <LogoOption/>
+  },
+  {
+    path: "/",
+    element: <App/>
   }
-}
-
-const Main = router();
+])
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <div className="container">
-      <Main />
+      <RouterProvider router={router} />
     </div>
     <Footer />
   </React.StrictMode>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,6 +456,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@remix-run/router@1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.3.tgz#d2509048d69dbb72d5389a14945339f1430b2d3c"
+  integrity sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==
+
 "@rollup/rollup-android-arm-eabi@4.11.0":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.11.0.tgz#78693f843483a511bce6ce1d8a153a49f4cbab87"
@@ -3064,6 +3069,21 @@ react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
+react-router-dom@^6.22.3:
+  version "6.22.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.22.3.tgz#9781415667fd1361a475146c5826d9f16752a691"
+  integrity sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==
+  dependencies:
+    "@remix-run/router" "1.15.3"
+    react-router "6.22.3"
+
+react-router@6.22.3:
+  version "6.22.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.3.tgz#9d9142f35e08be08c736a2082db5f0c9540a885e"
+  integrity sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==
+  dependencies:
+    "@remix-run/router" "1.15.3"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Refactoring type changes included:
* Add react-router and use it instead of simple router object
* Change signature of SwatchWIthForm so that it doesn't create the useState objects, they're created the level above
* Test all the outer components in /projects because otherwise you won't know if they're broken

Details about the Query Params change
* Unit tested the interface that does the transformations to-and-from the query params
* Variables are renamed in the query params since it's an external facing API (might change these names in the app later on)
* Did not write integration tests on App, I could have?

The searchHelpers file might make more sense as a class. I think writing it as helpers was just easier to think about