### PR TITLE
Separate out display data from the swatch data (Suggestion)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,6 @@ function App() {
     colorShift: sanitizeSearchParamInputs.colorShift(searchParams) || 0,
     staggerLengths: sanitizeSearchParamInputs.staggerLengths(searchParams),
     stitchPattern: sanitizeSearchParamInputs.stitchPattern(searchParams) || StitchPattern.moss,
-    showRowNumbers: false
   })
 
   useEffect(() => {

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -2,57 +2,58 @@ import './Form.scss'
 import CheckboxInput from './inputs/Checkbox'
 import TogglableColorPicker from './inputs/TogglableColorPicker'
 import IntegerInput from './inputs/Integer'
-import { StitchPattern, Color, ColorSequenceArray } from './types'
+import { Color, SwatchConfig } from './types'
 import { getRandomNotWhiteColor, totalColorSequenceLength } from './color'
 
-type SwatchConfigurationData = {
-  colorSequence: ColorSequenceArray,
-  stitchesPerRow: number,
-  stitchPattern: StitchPattern,
-  numberOfRows: number,
-  colorShift: number,
-  staggerLengths: boolean,
+type DisplayData = {
   showRowNumbers: boolean
 }
 
-type FormValue = keyof(SwatchConfigurationData)
+type FormValue = keyof(SwatchConfig) | keyof(DisplayData)
 
 const Form = (
-  { formData, setFormData } : 
+  { swatchData, setSwatchData, displayData, setDisplayData } :
   {
-    formData: SwatchConfigurationData,
-    setFormData: (data: SwatchConfigurationData) => void
+    swatchData: SwatchConfig,
+    setSwatchData: (data: SwatchConfig) => void,
+    displayData: DisplayData,
+    setDisplayData: (data: DisplayData) => void
   }
 ) => {
 
-  const { colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, stitchPattern, showRowNumbers } = formData;
+  const { colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, stitchPattern } = swatchData;
+  const { showRowNumbers } = displayData;
 
   const setFormValue = (name: FormValue, value : string | number | boolean) => {
-    setFormData({ ...formData, [name]: value});
+    if(Object.keys(swatchData).includes(name)) {
+      setSwatchData({ ...swatchData, [name]: value});
+    } else if(Object.keys(displayData).includes(name)) {
+      setDisplayData({ ...displayData, [name]: value});
+    }
   }
 
   const setColorSequenceLengthValue = (index : number, value : number) => {
-    const newFormData = { ...formData };
-    newFormData['colorSequence'][index]['length'] = value;
-    setFormData(newFormData);
+    const newSwatchData = { ...swatchData };
+    newSwatchData['colorSequence'][index]['length'] = value;
+    setSwatchData(newSwatchData);
   }
 
   const setColorSequenceColorValue = (color : Color, index : number) => {
-    const newFormData = {...formData};
-    newFormData['colorSequence'][index]['color'] = color;
-    setFormData(newFormData);
+    const newSwatchData = {...swatchData};
+    newSwatchData['colorSequence'][index]['color'] = color;
+    setSwatchData(newSwatchData);
   };
 
   const addColorToSequence = () => {
-    const newFormData = { ...formData };
-    newFormData['colorSequence'].push({color: getRandomNotWhiteColor(), length: 3});
-    setFormData(newFormData);
+    const newSwatchData = { ...swatchData };
+    newSwatchData['colorSequence'].push({color: getRandomNotWhiteColor(), length: 3});
+    setSwatchData(newSwatchData);
   }
 
   const removeColorFromSequence = (index: number) => {
-    const newFormData = { ...formData };
-    newFormData['colorSequence'].splice(index, 1);
-    setFormData(newFormData);
+    const newSwatchData = { ...swatchData };
+    newSwatchData['colorSequence'].splice(index, 1);
+    setSwatchData(newSwatchData);
   }
 
   const defaultPickerColors = [

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -1,16 +1,22 @@
 import Swatch from './Swatch';
 import Form from './Form';
 import { SwatchConfig } from './types'
+import { useState } from "react";
 
 function SwatchWithForm({swatchConfig, setSwatchConfig}  : { swatchConfig: SwatchConfig, setSwatchConfig: (arg0: SwatchConfig) => void}) {
+  const [displayData, setDisplayData] = useState({
+    showRowNumbers: false
+  })
   return (
   <div>
     <Form
-      formData={swatchConfig}
-      setFormData={setSwatchConfig}
+      swatchData={swatchConfig}
+      setSwatchData={setSwatchConfig}
+      displayData={displayData}
+      setDisplayData={setDisplayData}
     />
     <Swatch 
-    className={swatchConfig.showRowNumbers ? "numbered" : ""}
+    className={displayData.showRowNumbers ? "numbered" : ""}
     {...swatchConfig} />
   </div>
   );

--- a/src/projects/Doodle.tsx
+++ b/src/projects/Doodle.tsx
@@ -24,8 +24,7 @@ function Doodle() {
     numberOfRows: 9,
     colorShift: 1,
     staggerLengths: false,
-    stitchPattern: StitchPattern.jasmine,
-    showRowNumbers: false,
+    stitchPattern: StitchPattern.jasmine
   })
 
   return (

--- a/src/projects/LogoOption.tsx
+++ b/src/projects/LogoOption.tsx
@@ -23,8 +23,7 @@ function LogoOption() {
     numberOfRows: 40,
     colorShift: 0,
     staggerLengths: false,
-    stitchPattern: StitchPattern.moss,
-    showRowNumbers: false,
+    stitchPattern: StitchPattern.moss
   })
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,5 @@ export type SwatchConfig = {
     stitchPattern: StitchPattern,
     numberOfRows: number,
     colorShift: number,
-    staggerLengths: boolean,
-    showRowNumbers: boolean
+    staggerLengths: boolean
 }


### PR DESCRIPTION
showRowNumbers isn't really the same as swatch data, the app level shouldn't know about it.
@joanwolk Please let me know what you think about this. I have mixed feelings about how I actually did the implementation. It's kinda a SwatchWithForm level concern? But maybe we just split it into two forms anyway.