### PR TITLE
Move color helper type code into color helper file and unit test them

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -3,6 +3,7 @@ import CheckboxInput from './inputs/Checkbox'
 import TogglableColorPicker from './inputs/TogglableColorPicker'
 import IntegerInput from './inputs/Integer'
 import { StitchPattern, Color, ColorConfigArray } from './types'
+import { getRandomNotWhiteColor, totalColorSequenceLength } from './color'
 
 type SwatchConfigurationData = {
   colorConfig: ColorConfigArray,
@@ -44,8 +45,7 @@ const Form = (
 
   const addColorToConfig = () => {
     const newFormData = { ...formData };
-    const randomColor = Math.floor(Math.random()*16777214).toString(16).padStart(6,"0");
-    newFormData['colorConfig'].push({color: `#${randomColor}`, length: 3});
+    newFormData['colorConfig'].push({color: getRandomNotWhiteColor(), length: 3});
     setFormData(newFormData);
   }
 
@@ -55,15 +55,7 @@ const Form = (
     setFormData(newFormData);
   }
 
-  const printColorSequenceLength = () => {
-    let result = 0;
-    for (const i in colorConfig) {
-      result += colorConfig[i].length;
-    }
-    return result;
-  }
-
-  const defaultColors = [
+  const defaultPickerColors = [
     "#d9073a",
     "#f57605",
     "#fcdc4d",
@@ -73,7 +65,7 @@ const Form = (
     "#542e0f",
     "#fdf0d5"
   ]
-  const presetColors = [...new Set([...defaultColors, ...colorConfig.map((c) => c.color)])];
+  const presetColors = [...new Set([...defaultPickerColors, ...colorConfig.map((c) => c.color)])];
 
   return (
     <form
@@ -111,7 +103,7 @@ const Form = (
       <fieldset className='spec-fields'>
         <div>
           <em>
-            Total stitches in color sequence: {printColorSequenceLength()}
+            Total stitches in color sequence: {totalColorSequenceLength(colorConfig)}
           </em>
         </div>
 

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { nextStitchColorByIndex, isStringAColor } from './color'
+import { describe, expect, it, vi } from 'vitest'
+import { nextStitchColorByIndex, isStringAColor, getRandomNotWhiteColor, totalColorSequenceLength } from './color'
 import { ColorConfigArray } from './types'
 
 describe('nextStitchByColorIndex', () => {
@@ -57,5 +57,38 @@ describe('isStringAColor', () => {
     expect(isStringAColor('#gggggg')).toBe(false)
     expect(isStringAColor('ffffff')).toBe(false)
     expect(isStringAColor('#ffff')).toBe(false)
+  })
+})
+
+describe('getRandomNotWhiteColor', () => {
+  it('gets a random color', () => {
+    const randomColor = getRandomNotWhiteColor()
+    expect(isStringAColor(randomColor), `${randomColor} should match color string expectations`).toBe(true)
+  })
+  it('can be black', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const black = getRandomNotWhiteColor()
+    expect(black).toEqual('#000000')
+    expect(isStringAColor(black), `${black} should match color string expectations`).toBe(true)
+    vi.spyOn(Math, 'random').mockRestore();
+  })
+
+  it('cannot be white, but can be very light', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+    const almostWhite = getRandomNotWhiteColor()
+    expect(isStringAColor(almostWhite), `${almostWhite} should match color string expectations`).toBe(true)
+    expect(almostWhite).toEqual('#fffffe')
+    vi.spyOn(Math, 'random').mockRestore();
+  })
+})
+
+describe('totalColorSequenceLength', () => {
+  it('sums the lenght of the colors in the sequence', () => {
+    const config = [
+      {color: "#f00", length: 2},
+      {color: "#0f0", length: 3},
+      {color: "#00f", length: 4}
+    ] as ColorConfigArray
+    expect(totalColorSequenceLength(config)).toEqual(9)
   })
 })

--- a/src/color.ts
+++ b/src/color.ts
@@ -8,3 +8,15 @@ export function nextStitchColorByIndex(i : number, colorConfig : ColorConfigArra
 export function isStringAColor(s: string) : boolean {
   return /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(s);
 }
+
+export function getRandomNotWhiteColor() : Color {
+  return '#' + Math.floor(Math.random()*16777214).toString(16).padStart(6,"0") as Color
+}
+
+export function totalColorSequenceLength(colorConfig : ColorConfigArray) : number {
+  let result = 0;
+  for (const i in colorConfig) {
+    result += colorConfig[i].length;
+  }
+  return result;
+}


### PR DESCRIPTION
Rationale: This cleans up the form
I merged it once but fixed a type error on my merge
This reverts commit 990a8c9ca0aa7f9624d4c48b6c6af862714f2751.