### PR TITLE
[waiting for tooltips] add functionality to double the color sequence

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -49,6 +49,14 @@ const Form = (
     setFormData(newFormData);
   }
 
+  const duplicateColorSequence = () => {
+    const newFormData = {
+      ...formData,
+      colorSequence: [...formData.colorSequence, ...structuredClone(formData.colorSequence)]
+    };
+    setFormData(newFormData);
+  }
+
   const removeColorFromSequence = (index: number) => {
     const newFormData = { ...formData };
     newFormData['colorSequence'].splice(index, 1);
@@ -97,6 +105,7 @@ const Form = (
         ))}
         <div>
           <button type="button" onClick={addColorToSequence}>Add a color</button>
+          <button type="button" onClick={duplicateColorSequence}>Double the colors</button>
         </div>
       </fieldset>
 


### PR DESCRIPTION
I might want to wait to merge this until we have tooltips? But not sure. Also wondering if this should be tested.

<img width="737" alt="Screenshot 2024-03-10 at 4 06 22 PM" src="https://github.com/alenia/planned-pooling/assets/699890/4908b835-443a-443e-8690-e513a58eb24b">
