### PR TITLE
Add flag to stretch colors at experimental endpoint

### DIFF
--- a/src/Swatch.test.tsx
+++ b/src/Swatch.test.tsx
@@ -219,6 +219,54 @@ describe('Swatch', () => {
           expect(row1stitches[3]).toHaveStyle('background-color: #900')
           expect(row1stitches[4]).toHaveStyle('background-color: #000')
       })
+
+      it('color stretches with correct row lengths and colors', () => {
+        render(
+          <Swatch
+            colorSequence={[
+              {color: '#000', length: 1},
+              {color: '#100', length: 1},
+              {color: '#200', length: 1},
+              {color: '#300', length: 1},
+              {color: '#400', length: 1},
+              {color: '#500', length: 1},
+              {color: '#600', length: 1},
+              {color: '#700', length: 1},
+              {color: '#800', length: 1},
+              {color: '#900', length: 1},
+            ]}
+            stitchPattern={StitchPattern.moss}
+            staggerType='colorStretched'
+            stitchesPerRow={5}
+            numberOfRows={4}
+            staggerLengths={true}
+          />
+        )
+
+        const swatch = screen.getByTestId("swatch")
+        expect(swatch.children.length, 'should have correct numberOfRows').toEqual(4)
+        const row0stitches = swatch.children[0].children;
+        expect(row0stitches.length).toEqual(5)
+        expect(row0stitches[0]).toHaveStyle('background-color: #000')
+        expect(row0stitches[1]).toHaveStyle('background-color: #100')
+        expect(row0stitches[2]).toHaveStyle('background-color: #200')
+        expect(row0stitches[3]).toHaveStyle('background-color: #300')
+        expect(row0stitches[4]).toHaveStyle('background-color: #400')
+        const row1stitches = swatch.children[1].children;
+        expect(row1stitches.length).toEqual(5)
+        expect(row1stitches[0]).toHaveStyle('background-color: #500')
+        expect(row1stitches[1]).toHaveStyle('background-color: #600')
+        expect(row1stitches[2]).toHaveStyle('background-color: #700')
+        expect(row1stitches[3]).toHaveStyle('background-color: #800')
+        expect(row1stitches[4]).toHaveStyle('background-color: #900')
+        const row2stitches = swatch.children[2].children;
+        expect(row2stitches.length).toEqual(5)
+        expect(row2stitches[0]).toHaveStyle('background-color: #900')
+        expect(row2stitches[1]).toHaveStyle('background-color: #000')
+        expect(row2stitches[2]).toHaveStyle('background-color: #100')
+        expect(row2stitches[3]).toHaveStyle('background-color: #200')
+        expect(row2stitches[4]).toHaveStyle('background-color: #300')
+      })
     })
 
     it('renders an unstyled swatch', () => {

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -2,7 +2,11 @@ import Swatch from './Swatch';
 import Form from './Form';
 import { SwatchConfig } from './types'
 
-function SwatchWithForm({swatchConfig, setSwatchConfig}  : { swatchConfig: SwatchConfig, setSwatchConfig: (arg0: SwatchConfig) => void}) {
+function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType}  : {
+  swatchConfig: SwatchConfig,
+  setSwatchConfig: (arg0: SwatchConfig) => void,
+  staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed'
+}) {
   return (
   <div>
     <Form
@@ -10,8 +14,10 @@ function SwatchWithForm({swatchConfig, setSwatchConfig}  : { swatchConfig: Swatc
       setFormData={setSwatchConfig}
     />
     <Swatch 
-    className={swatchConfig.showRowNumbers ? "numbered" : ""}
-    {...swatchConfig} />
+      className={swatchConfig.showRowNumbers ? "numbered" : ""}
+      staggerType={staggerType}
+      {...swatchConfig}
+    />
   </div>
   );
 }

--- a/src/projects/StretchLengths.test.tsx
+++ b/src/projects/StretchLengths.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from "react-router-dom";
+import StretchLengths from './StretchLengths'
+
+describe('StretchLengths', () => {
+  it('renders the StretchLengths component with a swatch in it', () => {
+    render(
+      <MemoryRouter >
+        <StretchLengths />
+      </MemoryRouter>
+    )
+    expect(screen.getAllByTestId("swatch").length).toEqual(1)
+  })
+})

--- a/src/projects/StretchLengths.tsx
+++ b/src/projects/StretchLengths.tsx
@@ -1,0 +1,47 @@
+import SwatchWithForm from '../SwatchWithForm';
+import { StitchPattern, Color } from '../types'
+import { useState, useEffect } from "react";
+import { useSearchParams } from 'react-router-dom';
+import { URLSearchParamsFromSwatchConfig, sanitizeSearchParamInputs } from '../searchHelpers';
+
+const red = "#ff001d" as Color;
+const cream = "#fcf7eb" as Color;
+const ltblue = "#8dd0f2" as Color;
+const navy = "#0e0e66" as Color;
+
+function StretchLengths() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [swatchConfig, setSwatchConfig] = useState({
+    colorSequence: sanitizeSearchParamInputs.colorSequence(searchParams) || [
+      {color: navy, length: 3},
+      {color: red, length: 3},
+      {color: navy, length: 3},
+      {color: ltblue, length: 2},
+      {color: cream, length: 5},
+      {color: ltblue, length: 2},
+    ],
+    stitchesPerRow: sanitizeSearchParamInputs.stitchesPerRow(searchParams) || 18, //Note: explicitly ok not saving zero from search params here
+    numberOfRows: sanitizeSearchParamInputs.numberOfRows(searchParams) || 40, //Note: explicitly ok not pulling zero from search params here
+    colorShift: sanitizeSearchParamInputs.colorShift(searchParams) || 0,
+    staggerLengths: sanitizeSearchParamInputs.staggerLengths(searchParams),
+    stitchPattern: sanitizeSearchParamInputs.stitchPattern(searchParams) || StitchPattern.moss,
+    showRowNumbers: false
+  })
+
+  useEffect(() => {
+    const newSearchParams = URLSearchParamsFromSwatchConfig(swatchConfig)
+
+    setSearchParams(newSearchParams)
+  }, [swatchConfig, setSearchParams])
+
+  return (
+    <div>
+      <p>This is a experimental page</p>
+      <p>In this version, alternating row lengths uses the color stretching technique.</p>
+      <p>If you don&apos;t know what I&apos;m talking about use the main app.</p>
+      <SwatchWithForm swatchConfig={swatchConfig} setSwatchConfig={setSwatchConfig} staggerType={'colorStretched'}/>
+    </div>
+  );
+}
+
+export default StretchLengths;

--- a/src/wrapper.tsx
+++ b/src/wrapper.tsx
@@ -6,6 +6,7 @@ import Preview from './projects/Preview'
 import Sunflower from './projects/Sunflower'
 import Doodle from './projects/Doodle'
 import LogoOption from './projects/LogoOption'
+import StretchLengths from './projects/StretchLengths'
 import './index.scss'
 import {
   createBrowserRouter,
@@ -28,6 +29,10 @@ const router = createBrowserRouter([
   {
     path: "/branding-ideas",
     element: <LogoOption/>
+  },
+  {
+    path: "/experimental",
+    element: <StretchLengths/>
   },
   {
     path: "/",


### PR DESCRIPTION
This is the technique I use in the bag pattern/class. I played around to see what it would look like to do this in code and then figured I could put it at an experimental endpoint.