### PR TITLE
Allow user to duplicate color sequence on experimental endpoint

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -18,10 +18,11 @@ type SwatchConfigurationData = {
 type FormValue = keyof(SwatchConfigurationData)
 
 const Form = (
-  { formData, setFormData } : 
+  { formData, setFormData, showExperimentalFeatures } :
   {
     formData: SwatchConfigurationData,
-    setFormData: (data: SwatchConfigurationData) => void
+    setFormData: (data: SwatchConfigurationData) => void,
+    showExperimentalFeatures: boolean
   }
 ) => {
 
@@ -105,7 +106,7 @@ const Form = (
         ))}
         <div>
           <button type="button" onClick={addColorToSequence}>Add a color</button>
-          <button type="button" onClick={duplicateColorSequence}>Double the colors</button>
+          { showExperimentalFeatures ? <button type="button" onClick={duplicateColorSequence}>Double the colors</button> : ''}
         </div>
       </fieldset>
 

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -49,6 +49,14 @@ const Form = (
     setFormData(newFormData);
   }
 
+  const duplicateColorSequence = () => {
+    const newFormData = {
+      ...formData,
+      colorSequence: [...formData.colorSequence, ...structuredClone(formData.colorSequence)]
+    };
+    setFormData(newFormData);
+  }
+
   const removeColorFromSequence = (index: number) => {
     const newFormData = { ...formData };
     newFormData['colorSequence'].splice(index, 1);
@@ -97,6 +105,7 @@ const Form = (
         ))}
         <div>
           <button type="button" onClick={addColorToSequence}>Add a color</button>
+          <button type="button" onClick={duplicateColorSequence}>Double the colors</button>
         </div>
       </fieldset>
 

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -2,16 +2,18 @@ import Swatch from './Swatch';
 import Form from './Form';
 import { SwatchConfig } from './types'
 
-function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType}  : {
+function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperimentalFeatures}  : {
   swatchConfig: SwatchConfig,
   setSwatchConfig: (arg0: SwatchConfig) => void,
   staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed'
+  showExperimentalFeatures?: boolean,
 }) {
   return (
   <div>
     <Form
       formData={swatchConfig}
       setFormData={setSwatchConfig}
+      showExperimentalFeatures={!!showExperimentalFeatures}
     />
     <Swatch 
       className={swatchConfig.showRowNumbers ? "numbered" : ""}

--- a/src/projects/StretchLengths.tsx
+++ b/src/projects/StretchLengths.tsx
@@ -37,9 +37,17 @@ function StretchLengths() {
   return (
     <div>
       <p>This is a experimental page</p>
-      <p>In this version, alternating row lengths uses the color stretching technique.</p>
-      <p>If you don&apos;t know what I&apos;m talking about use the main app.</p>
-      <SwatchWithForm swatchConfig={swatchConfig} setSwatchConfig={setSwatchConfig} staggerType={'colorStretched'}/>
+      <ul>
+        <li>alternating row lengths uses the color stretching technique instead of changing lengths of rows</li>
+        <li>there is a button to double your colors</li>
+      </ul>
+      <p>If you don&apos;t know what I&apos;m talking about use the <a href='/'>main app.</a></p>
+      <SwatchWithForm
+        swatchConfig={swatchConfig}
+        setSwatchConfig={setSwatchConfig}
+        staggerType={'colorStretched'}
+        showExperimentalFeatures={true}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This adds a feature flag to the form.
There aren't any tests of the feature flag yet I might add that in a minute.

experimental endpoint:
<img width="837" alt="Screenshot 2024-03-11 at 9 46 34 AM" src="https://github.com/alenia/planned-pooling/assets/699890/ba808d33-4be4-4aa9-831e-bdd58a8e143d">

main app: 
<img width="833" alt="Screenshot 2024-03-11 at 9 49 33 AM" src="https://github.com/alenia/planned-pooling/assets/699890/de7d35cc-9de5-4823-acfb-491b656eb8e7">
