### PR TITLE
Some form refactors to help with readability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,6 @@ function App() {
     colorShift: sanitizeSearchParamInputs.colorShift(searchParams) || 0,
     staggerLengths: sanitizeSearchParamInputs.staggerLengths(searchParams),
     stitchPattern: sanitizeSearchParamInputs.stitchPattern(searchParams) || StitchPattern.moss,
-    showRowNumbers: false
   })
 
   useEffect(() => {

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -24,52 +24,52 @@ const defaultPickerColors = [
 ]
 
 function Form(
-  { formData, setFormData, staggerType, showExperimentalFeatures } :
+  { swatchData, setSwatchData, staggerType, showExperimentalFeatures } :
   {
-    formData: SwatchConfig,
-    setFormData: (data: SwatchConfig) => void,
+    swatchData: SwatchConfig,
+    setSwatchData: (data: SwatchConfig) => void,
     staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed',
     showExperimentalFeatures: boolean
   }
 ) {
 
-  const { colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, stitchPattern } = formData;
+  const { colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, stitchPattern } = swatchData;
 
   const setFormValue = (name: FormValue, value : string | number | boolean) => {
-    setFormData({ ...formData, [name]: value});
+    setSwatchData({ ...swatchData, [name]: value});
   }
 
   //color fields specific
   const setColorSequenceLengthValue = (index : number, value : number) => {
-    const newFormData = { ...formData };
-    newFormData['colorSequence'][index]['length'] = value;
-    setFormData(newFormData);
+    const newSwatchData = { ...swatchData };
+    newSwatchData['colorSequence'][index]['length'] = value;
+    setSwatchData(newSwatchData);
   }
 
   const setColorSequenceColorValue = (color : Color, index : number) => {
-    const newFormData = {...formData};
-    newFormData['colorSequence'][index]['color'] = color;
-    setFormData(newFormData);
+    const newSwatchData = {...swatchData};
+    newSwatchData['colorSequence'][index]['color'] = color;
+    setSwatchData(newSwatchData);
   };
 
   const removeColorFromSequence = (index: number) => {
-    const newFormData = { ...formData };
-    newFormData['colorSequence'].splice(index, 1);
-    setFormData(newFormData);
+    const newSwatchData = { ...swatchData };
+    newSwatchData['colorSequence'].splice(index, 1);
+    setSwatchData(newSwatchData);
   }
 
   const addColorToSequence = () => {
-    const newFormData = { ...formData };
-    newFormData['colorSequence'].push({color: getRandomNotWhiteColor(), length: 3});
-    setFormData(newFormData);
+    const newSwatchData = { ...swatchData };
+    newSwatchData['colorSequence'].push({color: getRandomNotWhiteColor(), length: 3});
+    setSwatchData(newSwatchData);
   }
 
   const duplicateColorSequence = () => {
-    const newFormData = {
-      ...formData,
-      colorSequence: [...formData.colorSequence, ...structuredClone(formData.colorSequence)]
+    const newSwatchData = {
+      ...swatchData,
+      colorSequence: [...swatchData.colorSequence, ...structuredClone(swatchData.colorSequence)]
     };
-    setFormData(newFormData);
+    setSwatchData(newSwatchData);
   }
 
   const presetColors = [...new Set([...defaultPickerColors, ...colorSequence.map((c) => c.color)])];

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -2,20 +2,10 @@ import './Form.scss'
 import CheckboxInput from './inputs/Checkbox'
 import TogglableColorPicker from './inputs/TogglableColorPicker'
 import IntegerInput from './inputs/Integer'
-import { StitchPattern, Color, ColorSequenceArray } from './types'
+import { Color, SwatchConfig } from './types'
 import { getRandomNotWhiteColor, totalColorSequenceLength } from './color'
 
-type SwatchConfigurationData = {
-  colorSequence: ColorSequenceArray,
-  stitchesPerRow: number,
-  stitchPattern: StitchPattern,
-  numberOfRows: number,
-  colorShift: number,
-  staggerLengths: boolean,
-  showRowNumbers: boolean
-}
-
-type FormValue = keyof(SwatchConfigurationData)
+type FormValue = keyof(SwatchConfig)
 
 function mod(n: number, m: number) {
   // because native JS % operator chokes on negatives
@@ -36,8 +26,8 @@ const defaultPickerColors = [
 function Form(
   { formData, setFormData, staggerType, showExperimentalFeatures } :
   {
-    formData: SwatchConfigurationData,
-    setFormData: (data: SwatchConfigurationData) => void,
+    formData: SwatchConfig,
+    setFormData: (data: SwatchConfig) => void,
     staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed',
     showExperimentalFeatures: boolean
   }

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -17,7 +17,23 @@ type SwatchConfigurationData = {
 
 type FormValue = keyof(SwatchConfigurationData)
 
-const Form = (
+function mod(n: number, m: number) {
+  // because native JS % operator chokes on negatives
+  return ((n % m) + m) % m;
+}
+
+const defaultPickerColors = [
+  "#d9073a",
+  "#f57605",
+  "#fcdc4d",
+  "#a1c349",
+  "#1c40b8",
+  "#7b0f9a",
+  "#542e0f",
+  "#fdf0d5"
+]
+
+function Form(
   { formData, setFormData, staggerType, showExperimentalFeatures } :
   {
     formData: SwatchConfigurationData,
@@ -25,7 +41,7 @@ const Form = (
     staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed',
     showExperimentalFeatures: boolean
   }
-) => {
+) {
 
   const { colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, stitchPattern, showRowNumbers } = formData;
 
@@ -33,6 +49,7 @@ const Form = (
     setFormData({ ...formData, [name]: value});
   }
 
+  //color fields specific
   const setColorSequenceLengthValue = (index : number, value : number) => {
     const newFormData = { ...formData };
     newFormData['colorSequence'][index]['length'] = value;
@@ -44,6 +61,12 @@ const Form = (
     newFormData['colorSequence'][index]['color'] = color;
     setFormData(newFormData);
   };
+
+  const removeColorFromSequence = (index: number) => {
+    const newFormData = { ...formData };
+    newFormData['colorSequence'].splice(index, 1);
+    setFormData(newFormData);
+  }
 
   const addColorToSequence = () => {
     const newFormData = { ...formData };
@@ -59,17 +82,9 @@ const Form = (
     setFormData(newFormData);
   }
 
-  const removeColorFromSequence = (index: number) => {
-    const newFormData = { ...formData };
-    newFormData['colorSequence'].splice(index, 1);
-    setFormData(newFormData);
-  }
+  const presetColors = [...new Set([...defaultPickerColors, ...colorSequence.map((c) => c.color)])];
 
-  function mod(n: number, m: number) {
-    // because native JS % operator chokes on negatives
-    return ((n % m) + m) % m;
-  }
-
+  //spec fields specific
   const colorShiftTooltip = () => {
     let tip = "Start the swatch this many stitches into your color sequence."
     const seqLength = totalColorSequenceLength(colorSequence)
@@ -91,18 +106,6 @@ const Form = (
     }
     return tip
   }
-
-  const defaultPickerColors = [
-    "#d9073a",
-    "#f57605",
-    "#fcdc4d",
-    "#a1c349",
-    "#1c40b8",
-    "#7b0f9a",
-    "#542e0f",
-    "#fdf0d5"
-  ]
-  const presetColors = [...new Set([...defaultPickerColors, ...colorSequence.map((c) => c.color)])];
 
   return (
     <form
@@ -200,7 +203,7 @@ const Form = (
         withTooltip={true}
       />
     </form>
-  );
+  )
 }
 
-export default Form;
+export default Form

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -43,7 +43,7 @@ function Form(
   }
 ) {
 
-  const { colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, stitchPattern, showRowNumbers } = formData;
+  const { colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, stitchPattern } = formData;
 
   const setFormValue = (name: FormValue, value : string | number | boolean) => {
     setFormData({ ...formData, [name]: value});
@@ -192,16 +192,6 @@ function Form(
           withTooltip={true}
         />
       </fieldset>
-
-      <CheckboxInput
-        className="checkbox-container"
-        label="Show Row Numbers"
-        title="Display row numbers at the beginning of each row."
-        name="showRowNumbers"
-        value={showRowNumbers}
-        setValue={(v: boolean) => setFormValue('showRowNumbers', v)}
-        withTooltip={true}
-      />
     </form>
   )
 }

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -1,13 +1,18 @@
 import Swatch from './Swatch';
 import Form from './Form';
 import { SwatchConfig } from './types'
+import { useState } from 'react';
+import CheckboxInput from './inputs/Checkbox'
 
-function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperimentalFeatures}  : {
+function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperimentalFeatures, showRowNumbersInitially}  : {
   swatchConfig: SwatchConfig,
   setSwatchConfig: (arg0: SwatchConfig) => void,
   staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed'
   showExperimentalFeatures?: boolean,
+  showRowNumbersInitially?: boolean,
 }) {
+  const [displayRowNumbers, setDisplayRowNumbers] = useState(!!showRowNumbersInitially)
+
   return (
   <div>
     <Form
@@ -16,8 +21,17 @@ function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperim
       staggerType={staggerType}
       showExperimentalFeatures={!!showExperimentalFeatures}
     />
+    <CheckboxInput
+      className="checkbox-container"
+      label="Show Row Numbers"
+      title="Display row numbers at the beginning of each row."
+      name="showRowNumbers"
+      value={displayRowNumbers}
+      setValue={(v: boolean) => setDisplayRowNumbers(v)}
+      withTooltip={true}
+    />
     <Swatch 
-      className={swatchConfig.showRowNumbers ? "numbered" : ""}
+      className={displayRowNumbers ? "numbered" : ""}
       staggerType={staggerType}
       {...swatchConfig}
     />

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -15,21 +15,23 @@ function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperim
 
   return (
   <div>
-    <Form
-      swatchData={swatchConfig}
-      setSwatchData={setSwatchConfig}
-      staggerType={staggerType}
-      showExperimentalFeatures={!!showExperimentalFeatures}
-    />
-    <CheckboxInput
-      className="checkbox-container"
-      label="Show Row Numbers"
-      title="Display row numbers at the beginning of each row."
-      name="showRowNumbers"
-      value={displayRowNumbers}
-      setValue={(v: boolean) => setDisplayRowNumbers(v)}
-      withTooltip={true}
-    />
+    <div className="container">
+      <Form
+        swatchData={swatchConfig}
+        setSwatchData={setSwatchConfig}
+        staggerType={staggerType}
+        showExperimentalFeatures={!!showExperimentalFeatures}
+      />
+      <CheckboxInput
+        className="checkbox-container"
+        label="Show Row Numbers"
+        title="Display row numbers at the beginning of each row."
+        name="showRowNumbers"
+        value={displayRowNumbers}
+        setValue={(v: boolean) => setDisplayRowNumbers(v)}
+        withTooltip={true}
+      />
+    </div>
     <Swatch 
       className={displayRowNumbers ? "numbered" : ""}
       staggerType={staggerType}

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -16,8 +16,8 @@ function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperim
   return (
   <div>
     <Form
-      formData={swatchConfig}
-      setFormData={setSwatchConfig}
+      swatchData={swatchConfig}
+      setSwatchData={setSwatchConfig}
       staggerType={staggerType}
       showExperimentalFeatures={!!showExperimentalFeatures}
     />

--- a/src/index.scss
+++ b/src/index.scss
@@ -10,3 +10,9 @@ body {
 main, footer {
   padding: 24px;
 }
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}

--- a/src/projects/Doodle.tsx
+++ b/src/projects/Doodle.tsx
@@ -25,7 +25,6 @@ function Doodle() {
     colorShift: 1,
     staggerLengths: false,
     stitchPattern: StitchPattern.jasmine,
-    showRowNumbers: false,
   })
 
   return (

--- a/src/projects/LogoOption.tsx
+++ b/src/projects/LogoOption.tsx
@@ -24,7 +24,6 @@ function LogoOption() {
     colorShift: 0,
     staggerLengths: false,
     stitchPattern: StitchPattern.moss,
-    showRowNumbers: false,
   })
 
   return (

--- a/src/projects/Parallax.tsx
+++ b/src/projects/Parallax.tsx
@@ -13,13 +13,12 @@ function Parallax() {
     colorShift: 0,
     staggerLengths: false,
     stitchPattern: StitchPattern.unstyled,
-    showRowNumbers: true,
   })
 
   return (
     <Fragment>
       <p>This is a page to help with the parallax beanie chart. If you want to design more planned pooling patterns, I recommend the <a href='/'>main app.</a></p>
-      <SwatchWithForm swatchConfig={swatchConfig} setSwatchConfig={setSwatchConfig} />
+      <SwatchWithForm swatchConfig={swatchConfig} setSwatchConfig={setSwatchConfig} showRowNumbersInitially={true} />
     </Fragment>
   );
 }

--- a/src/projects/StretchLengths.tsx
+++ b/src/projects/StretchLengths.tsx
@@ -25,7 +25,6 @@ function StretchLengths() {
     colorShift: sanitizeSearchParamInputs.colorShift(searchParams) || 0,
     staggerLengths: sanitizeSearchParamInputs.staggerLengths(searchParams),
     stitchPattern: sanitizeSearchParamInputs.stitchPattern(searchParams) || StitchPattern.moss,
-    showRowNumbers: false
   })
 
   useEffect(() => {

--- a/src/searchHelpers.test.ts
+++ b/src/searchHelpers.test.ts
@@ -14,7 +14,6 @@ describe('URLSearchParamsFromSwatchConfig', () => {
       colorShift: 5,
       staggerLengths: false,
       stitchPattern: StitchPattern.moss,
-      showRowNumbers: false
     } as SwatchConfig
 
     const searchParams = URLSearchParamsFromSwatchConfig(swatchConfig)
@@ -40,7 +39,6 @@ describe('sanitizeSearchParamInputs', () => {
       colorShift: 5,
       staggerLengths: true,
       stitchPattern: StitchPattern.moss,
-      showRowNumbers: false
     } as SwatchConfig
 
     const searchParams = URLSearchParamsFromSwatchConfig(swatchConfig)

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,5 @@ export type SwatchConfig = {
     stitchPattern: StitchPattern,
     numberOfRows: number,
     colorShift: number,
-    staggerLengths: boolean,
-    showRowNumbers: boolean
+    staggerLengths: boolean
 }


### PR DESCRIPTION
This replaces #73 

* Move methods around in form to better match where they're used and whether they require the form closure
* Move showRowNumbers checkbox to the SwatchWithForm
* Rename formData to swatchData since it's just the swatchData now