### PR TITLE
change checkbox so that the class comes from the component

### DIFF
--- a/src/Form.scss
+++ b/src/Form.scss
@@ -29,7 +29,7 @@ fieldset {
     gap: 0.5em;
   }
 }
-.checkbox-container {
+.checkbox-input {
   position: relative;
   display: flex;
   align-items: center;
@@ -37,10 +37,10 @@ fieldset {
   label {
     margin: 0 0.25em 0 0.5em;
   }
-}
 
-input[type=checkbox] {
-  margin: 0;
+  input[type=checkbox] {
+    margin: 0;
+  }
 }
 
 .input-group {

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -173,7 +173,6 @@ function Form(
           />
 
         <CheckboxInput
-          className="checkbox-container"
           title={staggerLengthsTooltip()}
           label="Alternate row lengths"
           name="staggerLengths"

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -23,7 +23,6 @@ function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperim
         showExperimentalFeatures={!!showExperimentalFeatures}
       />
       <CheckboxInput
-        className="checkbox-container"
         label="Show Row Numbers"
         title="Display row numbers at the beginning of each row."
         name="showRowNumbers"

--- a/src/inputs/Checkbox.tsx
+++ b/src/inputs/Checkbox.tsx
@@ -2,9 +2,8 @@ import ClickableTooltip from '../ClickableTooltip';
 
 
 function Checkbox(
-  { className, value, name, label, title, setValue, withTooltip}
-  : { className: string,
-      value: boolean,
+  { value, name, label, title, setValue, withTooltip}
+  : { value: boolean,
       name: string,
       label: string,
       title: string,
@@ -14,7 +13,7 @@ function Checkbox(
   ){
 
   return (
-      <div className={className}>
+      <div className="checkbox-input">
         <input
           type="checkbox"
           onChange={


### PR DESCRIPTION
This better matches the integer input, and then when we add a <Checkbox> it's styled correctly without having to add a className. In the future if we have <Checkbox>'s that look different we can figure that out, but I think that's the right look