### PR TITLE
Panel buttons

### DIFF
--- a/src/Form.scss
+++ b/src/Form.scss
@@ -1,7 +1,20 @@
 form {
   display: grid;
   grid-template-columns: max-content max-content;
-  grid-gap: 0.5em;
+  grid-gap: 0.75em;
+  margin-bottom: 0.75em;
+
+  &.wide-first-column {
+    grid-template-columns: 475px max-content;
+
+    fieldset {
+      width: 450px;
+    }
+
+    .spec-fields {
+      width: fit-content;
+    }
+  }
 }
 
 fieldset {
@@ -9,10 +22,8 @@ fieldset {
   border-radius: 8px;
   border: 1px solid #bbbbbb;
   padding: 12px;
-}
+  margin: 0;
 
-.color-fields,
-.spec-fields {
   & > div {
     margin-bottom: 0.5em;
     height: 2em;
@@ -29,6 +40,7 @@ fieldset {
     gap: 0.5em;
   }
 }
+
 .checkbox-input {
   position: relative;
   display: flex;
@@ -91,7 +103,7 @@ fieldset {
   position: relative;
 }
 
-.color-buttons {
+.buttons {
   display: flex;
   align-items: flex-end;
   justify-content: left;
@@ -135,6 +147,18 @@ fieldset {
     display: grid;
     grid-template-columns: 1fr;
     grid-gap: 0.5em;
+
+    &.wide-first-column {
+      grid-template-columns: 1fr;
+
+      fieldset {
+        width: inherit;
+      }
+
+      .spec-fields {
+        width: inherit;
+      }
+    }
   }
 
   fieldset {

--- a/src/Form.scss
+++ b/src/Form.scss
@@ -7,12 +7,8 @@ form {
   &.wide-first-column {
     grid-template-columns: 475px max-content;
 
-    fieldset {
+    fieldset:first-child {
       width: 450px;
-    }
-
-    .spec-fields {
-      width: fit-content;
     }
   }
 }
@@ -151,11 +147,7 @@ fieldset {
     &.wide-first-column {
       grid-template-columns: 1fr;
 
-      fieldset {
-        width: inherit;
-      }
-
-      .spec-fields {
+      fieldset:first-child {
         width: inherit;
       }
     }

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -24,12 +24,13 @@ const defaultPickerColors = [
 ]
 
 function Form(
-  { swatchData, setSwatchData, staggerType, showExperimentalFeatures } :
+  { swatchData, setSwatchData, staggerType, showExperimentalFeatures, formClasses } :
   {
     swatchData: SwatchConfig,
     setSwatchData: (data: SwatchConfig) => void,
     staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed',
-    showExperimentalFeatures: boolean
+    showExperimentalFeatures: boolean,
+    formClasses?: string,
   }
 ) {
 
@@ -108,6 +109,7 @@ function Form(
       onSubmit={(e) => {
         e.preventDefault();
       }}
+      className={formClasses}
     >
       <fieldset className='color-fields'>
         {colorSequence.map((obj, index) => (
@@ -131,7 +133,7 @@ function Form(
             <button type="button" onClick={() => removeColorFromSequence(index)}>Remove color</button>
           </div>
         ))}
-        <div className="color-buttons">
+        <div className="buttons">
           <button type="button" onClick={addColorToSequence}>Add a color</button>
           { showExperimentalFeatures ? <button type="button" onClick={duplicateColorSequence}>Double the colors</button> : ''}
         </div>

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -24,13 +24,13 @@ const defaultPickerColors = [
 ]
 
 function Form(
-  { swatchData, setSwatchData, staggerType, showExperimentalFeatures, formClasses } :
+  { swatchData, setSwatchData, staggerType, showExperimentalFeatures, className } :
   {
     swatchData: SwatchConfig,
     setSwatchData: (data: SwatchConfig) => void,
     staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed',
     showExperimentalFeatures: boolean,
-    formClasses?: string,
+    className?: string,
   }
 ) {
 
@@ -109,7 +109,7 @@ function Form(
       onSubmit={(e) => {
         e.preventDefault();
       }}
-      className={formClasses}
+      className={className}
     >
       <fieldset className='color-fields'>
         {colorSequence.map((obj, index) => (

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -22,7 +22,7 @@ function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperim
         setSwatchData={setSwatchConfig}
         staggerType={staggerType}
         showExperimentalFeatures={!!showExperimentalFeatures}
-        formClasses={formClasses}
+        className={formClasses}
       />
       <CheckboxInput
         label="Show Row Numbers"

--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -4,12 +4,13 @@ import { SwatchConfig } from './types'
 import { useState } from 'react';
 import CheckboxInput from './inputs/Checkbox'
 
-function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperimentalFeatures, showRowNumbersInitially}  : {
+function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperimentalFeatures, showRowNumbersInitially, formClasses}  : {
   swatchConfig: SwatchConfig,
   setSwatchConfig: (arg0: SwatchConfig) => void,
   staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed'
   showExperimentalFeatures?: boolean,
   showRowNumbersInitially?: boolean,
+  formClasses?: string,
 }) {
   const [displayRowNumbers, setDisplayRowNumbers] = useState(!!showRowNumbersInitially)
 
@@ -21,6 +22,7 @@ function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperim
         setSwatchData={setSwatchConfig}
         staggerType={staggerType}
         showExperimentalFeatures={!!showExperimentalFeatures}
+        formClasses={formClasses}
       />
       <CheckboxInput
         label="Show Row Numbers"

--- a/src/projects/DoloresParkTote.tsx
+++ b/src/projects/DoloresParkTote.tsx
@@ -36,7 +36,29 @@ function DoloresParkTote() {
       ...swatchConfig,
       colorSequence: newColorSequence,
       stitchesPerRow: totalColorSequenceLength(newColorSequence),
-      colorShift: 0
+      colorShift: 0,
+    })
+  }
+  const setPanel1Configuration = () => {
+    setSwatchConfig({
+      ...swatchConfig,
+      stitchesPerRow: totalColorSequenceLength(swatchConfig.colorSequence),
+      staggerLengths: false,
+
+    })
+  }
+  const setPanel2Configuration = () => {
+    setSwatchConfig({
+      ...swatchConfig,
+      stitchesPerRow: totalColorSequenceLength(swatchConfig.colorSequence),
+      staggerLengths: true,
+    })
+  }
+  const setBandConfiguration = () => {
+    setSwatchConfig({
+      ...swatchConfig,
+      stitchesPerRow: Math.floor(totalColorSequenceLength(swatchConfig.colorSequence)/2),
+      staggerLengths: false,
     })
   }
 
@@ -47,16 +69,26 @@ function DoloresParkTote() {
       <p> For Panel 2: Select <em>Stretch Colors</em> to preview the color stretching technique</p>
       <p> For the band: Turn off Stretch Colors and set <em>Stitches Per Row</em> to half of your color sequence</p>
       <p> You can play with the color shift to change where you start your band or Panel 1</p>
-      <DropdownInput
-        label="Pick a colorway"
-        name="colorway"
-        title="Pick from a Circulo DUNA colorway"
-        value={selectedColorway}
-        setValue={resetColorway}
-        items={[...Object.keys(dunaColorways).map((id) => (
-          { label: dunaColorways[id].colorway, value: id }
-        )), {label: 'Custom (choose your own colors)', value: 'custom'}]}
-      />
+      <fieldset>
+        <DropdownInput
+          label="Pick a colorway"
+          name="colorway"
+          title="Pick from a Circulo DUNA colorway"
+          value={selectedColorway}
+          setValue={resetColorway}
+          items={[...Object.keys(dunaColorways).map((id) => (
+            { label: dunaColorways[id].colorway, value: id }
+          )), {label: 'Custom (choose your own colors)', value: 'custom'}]}
+        />
+        <label>
+          Set the stitches per row and color stretching based on your panel:
+        </label>
+        <div className="color-buttons">
+          <button type="button" onClick={setPanel1Configuration}>Panel 1 (stripes)</button>
+          <button type="button" onClick={setPanel2Configuration}>Panel 2 (color stretching)</button>
+          <button type="button" onClick={setBandConfiguration}>Band (half width)</button>
+        </div>
+      </fieldset>
       <SwatchWithForm
         swatchConfig={swatchConfig}
         setSwatchConfig={setSwatchConfig}

--- a/src/projects/DoloresParkTote.tsx
+++ b/src/projects/DoloresParkTote.tsx
@@ -57,6 +57,7 @@ function DoloresParkTote() {
   const setBandConfiguration = () => {
     setSwatchConfig({
       ...swatchConfig,
+      numberOfRows: totalColorSequenceLength(swatchConfig.colorSequence)*4,
       stitchesPerRow: Math.floor(totalColorSequenceLength(swatchConfig.colorSequence)/2),
       staggerLengths: false,
     })

--- a/src/projects/DoloresParkTote.tsx
+++ b/src/projects/DoloresParkTote.tsx
@@ -81,7 +81,7 @@ function DoloresParkTote() {
           )), {label: 'Custom (choose your own colors)', value: 'custom'}]}
         />
         <label>
-          Set the stitches per row and color stretching based on your panel:
+          Set the stitches per row and pooling technique based on your panel:
         </label>
         <div className="color-buttons">
           <button type="button" onClick={setPanel1Configuration}>Panel 1 (stripes)</button>

--- a/src/projects/DoloresParkTote.tsx
+++ b/src/projects/DoloresParkTote.tsx
@@ -57,7 +57,6 @@ function DoloresParkTote() {
   const setBandConfiguration = () => {
     setSwatchConfig({
       ...swatchConfig,
-      numberOfRows: totalColorSequenceLength(swatchConfig.colorSequence)*4,
       stitchesPerRow: Math.floor(totalColorSequenceLength(swatchConfig.colorSequence)/2),
       staggerLengths: false,
     })

--- a/src/projects/DoloresParkTote.tsx
+++ b/src/projects/DoloresParkTote.tsx
@@ -77,7 +77,7 @@ function DoloresParkTote() {
       >
         <fieldset>
           <DropdownInput
-            label="Pick a colorway"
+            label="Pick a colorway:"
             name="colorway"
             title="Pick from a Circulo DUNA colorway"
             value={selectedColorway}

--- a/src/projects/DoloresParkTote.tsx
+++ b/src/projects/DoloresParkTote.tsx
@@ -69,31 +69,39 @@ function DoloresParkTote() {
       <p> For Panel 2: Select <em>Stretch Colors</em> to preview the color stretching technique</p>
       <p> For the band: Turn off Stretch Colors and set <em>Stitches Per Row</em> to half of your color sequence</p>
       <p> You can play with the color shift to change where you start your band or Panel 1</p>
-      <fieldset>
-        <DropdownInput
-          label="Pick a colorway"
-          name="colorway"
-          title="Pick from a Circulo DUNA colorway"
-          value={selectedColorway}
-          setValue={resetColorway}
-          items={[...Object.keys(dunaColorways).map((id) => (
-            { label: dunaColorways[id].colorway, value: id }
-          )), {label: 'Custom (choose your own colors)', value: 'custom'}]}
-        />
-        <label>
-          Set the stitches per row and pooling technique based on your panel:
-        </label>
-        <div className="color-buttons">
-          <button type="button" onClick={setPanel1Configuration}>Panel 1 (stripes)</button>
-          <button type="button" onClick={setPanel2Configuration}>Panel 2 (color stretching)</button>
-          <button type="button" onClick={setBandConfiguration}>Band (half width)</button>
-        </div>
-      </fieldset>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}
+        className='wide-first-column'
+      >
+        <fieldset>
+          <DropdownInput
+            label="Pick a colorway"
+            name="colorway"
+            title="Pick from a Circulo DUNA colorway"
+            value={selectedColorway}
+            setValue={resetColorway}
+            items={[...Object.keys(dunaColorways).map((id) => (
+              { label: dunaColorways[id].colorway, value: id }
+            )), {label: 'Custom (choose your own colors)', value: 'custom'}]}
+          />
+          <label>
+            Set the stitches per row and pooling technique based on your panel:
+          </label>
+          <div className="buttons">
+            <button type="button" onClick={setPanel1Configuration}>Panel 1 (stripes)</button>
+            <button type="button" onClick={setPanel2Configuration}>Panel 2 (color stretching)</button>
+            <button type="button" onClick={setBandConfiguration}>Band (half width)</button>
+          </div>
+        </fieldset>
+      </form>
       <SwatchWithForm
         swatchConfig={swatchConfig}
         setSwatchConfig={setSwatchConfig}
         showRowNumbersInitially={true}
         staggerType={'colorStretched'}
+        formClasses='wide-first-column'
       />
     </Fragment>
   );


### PR DESCRIPTION
Desktop form layout on Dolores Park tote
<img width="837" alt="Screenshot 2024-03-29 at 3 07 13 PM" src="https://github.com/alenia/planned-pooling/assets/284712/6ebf4d0e-6943-4616-b1a4-9eeedd4c76c9">

Desktop form layout on homepage (slightly narrower first column)
<img width="798" alt="Screenshot 2024-03-29 at 3 09 28 PM" src="https://github.com/alenia/planned-pooling/assets/284712/84c43f6a-b4ec-413f-a11c-fdc3fb0050c7">

Mobile form layout on Dolores Park tote
<img width="737" alt="Screenshot 2024-03-29 at 3 07 26 PM" src="https://github.com/alenia/planned-pooling/assets/284712/043c5eca-dba2-4271-8f90-df448b35fe64">


