### PR TITLE
remove container around form and checkbox

### DIFF
--- a/src/SwatchWithForm.tsx
+++ b/src/SwatchWithForm.tsx
@@ -16,23 +16,21 @@ function SwatchWithForm({swatchConfig, setSwatchConfig, staggerType, showExperim
 
   return (
   <div>
-    <div className="container">
-      <Form
-        swatchData={swatchConfig}
-        setSwatchData={setSwatchConfig}
-        staggerType={staggerType}
-        showExperimentalFeatures={!!showExperimentalFeatures}
-        className={formClasses}
-      />
-      <CheckboxInput
-        label="Show Row Numbers"
-        title="Display row numbers at the beginning of each row."
-        name="showRowNumbers"
-        value={displayRowNumbers}
-        setValue={(v: boolean) => setDisplayRowNumbers(v)}
-        withTooltip={true}
-      />
-    </div>
+    <Form
+      swatchData={swatchConfig}
+      setSwatchData={setSwatchConfig}
+      staggerType={staggerType}
+      showExperimentalFeatures={!!showExperimentalFeatures}
+      className={formClasses}
+    />
+    <CheckboxInput
+      label="Show Row Numbers"
+      title="Display row numbers at the beginning of each row."
+      name="showRowNumbers"
+      value={displayRowNumbers}
+      setValue={(v: boolean) => setDisplayRowNumbers(v)}
+      withTooltip={true}
+    />
     <Swatch 
       className={displayRowNumbers ? "numbered" : ""}
       staggerType={staggerType}


### PR DESCRIPTION
Because of the bottom margin on form, we don't need the container with the gap in it, so I'm removing that from around the form and checkbox. This fixes the extra spacing between the form and checkbox

<img width="743" alt="Screenshot 2024-03-30 at 8 49 10 AM" src="https://github.com/alenia/planned-pooling/assets/699890/61d85f21-0c22-45b7-917f-01fe06a185ac">
<img width="549" alt="Screenshot 2024-03-30 at 8 49 20 AM" src="https://github.com/alenia/planned-pooling/assets/699890/b9f4503b-1754-40ee-a620-598a8ee664fe">
