### PR TITLE
add interwoven stitch mixin, fix which stitch is first in granny stitch

### DIFF
--- a/src/Swatch.scss
+++ b/src/Swatch.scss
@@ -17,13 +17,6 @@ version of preview. Hopefully there will be a test of this diff at some point*/
     position: absolute;
     margin: 5px -15px;
   }
-  &.moss:not(.staggered), &.hdc:not(.staggered) {
-    .crow:nth-child(2n + 1) {
-      &::before {
-        margin: 5px -30px;
-      }
-    }
-  }
 }
 
 /*Shared swatch styling including row-reverse layout*/
@@ -58,11 +51,7 @@ version of preview. Hopefully there will be a test of this diff at some point*/
 
 
 /*Basic layout swatches: moss, hdc, granny, shell, v-stitch*/
-$basicStitchHeight: 28px;
-.swatch.moss, .swatch.hdc {
-  $stitchHeight: $basicStitchHeight;
-  $stitchWidth: 14px;
-  $spacing: 1px;
+@mixin interwovenStitch($stitchHeight, $stitchWidth, $spacing, $overlapRatio) {
   &.staggered {
     .crow:nth-child(2n) {
       margin: 0 $stitchWidth + $spacing;
@@ -84,29 +73,28 @@ $basicStitchHeight: 28px;
     margin-right: $stitchWidth + $spacing;
     margin-left: $spacing;
     margin-top: $spacing;
+    margin-bottom: -1 * $overlapRatio * $stitchHeight;
   }
+  &.numbered:not(.staggered) {
+    .crow:nth-child(2n + 1) {
+      &::before {
+        margin-left: -1*$stitchWidth - 15px;
+      }
+    }
+  }
+
 }
 
-.swatch.moss .stitch {
-  margin-bottom: -0.5*$basicStitchHeight;
+.swatch.moss {
+  @include interwovenStitch(28px, 14px, 1px, 0.5)
 }
 
-.swatch.hdc .stitch {
-  margin-bottom: -.3*$basicStitchHeight;
+.swatch.hdc {
+  @include interwovenStitch(28px, 14px, 1px, 0.3)
 }
 
 .swatch.granny {
-  $stitchHeight: 20px;
-  .crow:nth-child(2n) {
-    margin: 0 $stitchHeight;
-  }
-  .stitch {
-    box-sizing: border-box;
-    border: 1px solid black;
-    height: $stitchHeight;
-    width: $stitchHeight;
-    margin: 0 $stitchHeight -.2*$stitchHeight 0;
-  }
+  @include interwovenStitch(20px, 20px, 0, 0.2);
 }
 
 .swatch.shell {


### PR DESCRIPTION
I have screenshots of my diffs with production for moss, hdc, and granny. The numbers might be in slightly different locations for moss and hdc, and granny staggered lays out very differently than it did before

Granny stitch:
<img width="494" alt="Screenshot 2024-03-31 at 9 34 56 AM" src="https://github.com/alenia/planned-pooling/assets/699890/f85ff014-3b90-4955-a453-fecb9e5686d7">
<img width="504" alt="Screenshot 2024-03-31 at 9 35 02 AM" src="https://github.com/alenia/planned-pooling/assets/699890/093dee68-6052-4caa-bece-2c398f6fd0e5">

hdc:
<img width="415" alt="Screenshot 2024-03-31 at 9 34 05 AM" src="https://github.com/alenia/planned-pooling/assets/699890/9922cd14-0208-4fcb-9031-d19a30b9bcee">
<img width="419" alt="Screenshot 2024-03-31 at 9 34 11 AM" src="https://github.com/alenia/planned-pooling/assets/699890/b8363222-bad1-4c4d-b5f3-699d6ca682ce">

moss:
<img width="381" alt="Screenshot 2024-03-31 at 9 33 08 AM" src="https://github.com/alenia/planned-pooling/assets/699890/3dc3d3aa-21f9-4ad8-af9a-c85eaddc5e32">
<img width="408" alt="Screenshot 2024-03-31 at 9 33 36 AM" src="https://github.com/alenia/planned-pooling/assets/699890/7b3ffc91-93be-437e-9e36-2b9a6e0698db">
