### PR TITLE
swatch now works properly in strict mode

### DIFF
--- a/src/Swatch.test.tsx
+++ b/src/Swatch.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { StitchPattern, SwatchConfig, ColorSequenceArray } from './types'
@@ -28,6 +29,83 @@ describe('Swatch', () => {
   })
   describe('unclustered swatches', () => {
     describe('moss stitch', () => {
+      it('properly colors stitches when there are multiple swatches in strict mode', () => {
+        render(
+          <StrictMode>
+            <Swatch
+              colorSequence={[
+                {color: '#aaa', length: 1},
+                {color: '#bbb', length: 1},
+                {color: '#ccc', length: 1},
+                {color: '#ddd', length: 1},
+                {color: '#eee', length: 1},
+              ]}
+              stitchPattern={StitchPattern.moss}
+              stitchesPerRow={4}
+              colorShift={1}
+              numberOfRows={2}
+              staggerLengths={false}
+            />
+            <Swatch
+              colorSequence={[
+                {color: '#aaa', length: 1},
+                {color: '#bbb', length: 1},
+                {color: '#ccc', length: 1},
+                {color: '#ddd', length: 1},
+                {color: '#eee', length: 1},
+              ]}
+              stitchPattern={StitchPattern.moss}
+              stitchesPerRow={4}
+              colorShift={1}
+              numberOfRows={2}
+              staggerLengths={false}
+            />
+          </StrictMode>
+        )
+
+        const swatches = screen.getAllByTestId("swatch")
+        expect(swatches[0].children[0].children[0]).toHaveStyle('background-color: #bbb')
+        expect(swatches[1].children[0].children[0]).toHaveStyle('background-color: #bbb')
+      })
+      it('properly colors stitches when there are multiple swatches in strict mode, color stretched', () => {
+        render(
+          <StrictMode>
+            <Swatch
+              colorSequence={[
+                {color: '#aaa', length: 1},
+                {color: '#bbb', length: 1},
+                {color: '#ccc', length: 1},
+                {color: '#ddd', length: 1},
+                {color: '#eee', length: 1},
+              ]}
+              stitchPattern={StitchPattern.moss}
+              stitchesPerRow={4}
+              colorShift={1}
+              numberOfRows={2}
+              staggerLengths={true}
+              staggerType="colorStretched"
+            />
+            <Swatch
+              colorSequence={[
+                {color: '#aaa', length: 1},
+                {color: '#bbb', length: 1},
+                {color: '#ccc', length: 1},
+                {color: '#ddd', length: 1},
+                {color: '#eee', length: 1},
+              ]}
+              stitchPattern={StitchPattern.moss}
+              stitchesPerRow={4}
+              colorShift={1}
+              numberOfRows={2}
+              staggerLengths={false}
+            />
+          </StrictMode>
+        )
+
+        const swatches = screen.getAllByTestId("swatch")
+        expect(swatches[0].children[0].children[0]).toHaveStyle('background-color: #bbb')
+        expect(swatches[1].children[0].children[0]).toHaveStyle('background-color: #bbb')
+      })
       it('renders a moss stitch swatch', () => {
         render(
           <Swatch
@@ -390,6 +468,41 @@ describe('Swatch', () => {
           expect(row1Clusters[1].children[0]).toHaveStyle('background-color: #800')
           expect(row1Clusters[1].children[1]).toHaveStyle('background-color: #900')
           expect(row1Clusters[1].children[2]).toHaveStyle('background-color: #000')
+        })
+        it('properly puts the colors on the stitches when there is a prepended stitch in strict mode', () => {
+          render(
+            <StrictMode>
+              <Swatch
+                colorSequence={[
+                  {color: '#aaa', length: 1},
+                  {color: '#bbb', length: 1},
+                  {color: '#ccc', length: 1},
+                  {color: '#ddd', length: 1},
+                  {color: '#eee', length: 1},
+                ]}
+                stitchPattern={StitchPattern.jasmine}
+                stitchesPerRow={2}
+                numberOfRows={4}
+                staggerLengths={false}
+              />
+              <Swatch
+                colorSequence={[
+                  {color: '#aaa', length: 1},
+                  {color: '#bbb', length: 1},
+                  {color: '#ccc', length: 1},
+                  {color: '#ddd', length: 1},
+                  {color: '#eee', length: 1},
+                ]}
+                stitchPattern={StitchPattern.jasmine}
+                stitchesPerRow={2}
+                numberOfRows={4}
+                staggerLengths={false}
+              />
+            </StrictMode>
+          )
+          const swatches = screen.getAllByTestId("swatch")
+          expect(swatches[0].children[0].children[0].children[0]).toHaveStyle('background-color: #aaa')
+          expect(swatches[1].children[0].children[0].children[0]).toHaveStyle('background-color: #aaa')
         })
       })
 

--- a/src/Swatch.tsx
+++ b/src/Swatch.tsx
@@ -46,14 +46,21 @@ function Stitch ({color} : { color: Color}) {
 }
 
 function ClusteredSwatch(
-  { clustersPerRow, numberOfRows, clusterConfig, buildStitch}
+  { clustersPerRow, numberOfRows, clusterConfig, nextColor}
   : {
     clustersPerRow: number,
     numberOfRows: number,
     clusterConfig: ClusterConfiguration,
-    buildStitch: () => ReactNode
+    nextColor: (index: number) => Color
   }
 ) {
+  let stitchIndex = 0
+
+  const buildStitch = () => {
+    const color = nextColor(stitchIndex)
+    stitchIndex++;
+    return <Stitch key={stitchIndex} color={color}/>;
+  }
   return (
     [...Array(numberOfRows)].map((e, i) => (
       <Crow key={i}>
@@ -78,16 +85,26 @@ function ClusteredSwatch(
 }
 
 function StandardSwatch(
-  { stitchesPerRow, numberOfRows, staggerLengths, staggerType, buildStitch, buildColorStretchedStitch}
+  { stitchesPerRow, numberOfRows, staggerLengths, staggerType, nextColor}
   : {
     stitchesPerRow: number,
     numberOfRows: number,
     staggerLengths: boolean,
-    staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed'
-    buildStitch: () => ReactNode,
-    buildColorStretchedStitch: () => ReactNode
+    staggerType?: 'normal' | 'colorStretched' | 'colorSwallowed',
+    nextColor: (index: number) => Color,
   }
 ) {
+  let stitchIndex = 0;
+  const buildColorStretchedStitch = () => {
+    const color = nextColor(stitchIndex)
+    return <Stitch key={`stretch${stitchIndex}`} color={color}/>;
+  }
+
+  const buildStitch = () => {
+    const color = nextColor(stitchIndex)
+    stitchIndex++;
+    return <Stitch key={stitchIndex} color={color}/>;
+  }
   if(staggerLengths && staggerType === 'colorStretched') {
     return (
       [...Array(numberOfRows)].map((e, i) => {
@@ -145,18 +162,12 @@ function Swatch(
     staggered ? 'staggered' : ''
   ]
 
-  let stitchIndex = 0;
-
-  const buildColorStretchedStitch = () => {
-    const color = nextStitchColorByIndex(stitchIndex, colorSequence, {colorShift})
-    return <Stitch key={`stretch${stitchIndex}`} color={color}/>;
-  }
-
-  const buildStitch = () => {
+  const buildStitch = (stitchIndex: number) => {
     const color = nextStitchColorByIndex(stitchIndex, colorSequence, {colorShift})
     stitchIndex++;
     return <Stitch key={stitchIndex} color={color}/>;
   }
+  const nextColor = (index: number) => nextStitchColorByIndex(index, colorSequence, {colorShift})
 
   return <div data-testid="swatch" className={classNames.join(' ')}>
     {
@@ -165,7 +176,7 @@ function Swatch(
         clustersPerRow={stitchesPerRow}
         clusterConfig={clusterConfig}
         numberOfRows={numberOfRows}
-        buildStitch={buildStitch}
+        nextColor={nextColor}
       />
 
       :
@@ -174,8 +185,7 @@ function Swatch(
         numberOfRows={numberOfRows}
         staggerLengths={staggerLengths}
         staggerType={staggerType}
-        buildStitch={buildStitch}
-        buildColorStretchedStitch={buildColorStretchedStitch}
+        nextColor={nextColor}
       />
     }
   </div>;


### PR DESCRIPTION
each swatch type is responsible for its own index, rather than being a side effect passed in from the parent.