### PR TITLE
Diffusion scarf Endpoint for new design

### DIFF
--- a/src/ColorSequenceInfo.tsx
+++ b/src/ColorSequenceInfo.tsx
@@ -1,0 +1,32 @@
+import { totalColorSequenceLength, shiftedColorSequenceArray } from './color'
+import { ColorSequenceArray } from './types'
+import fontColorContrast from 'font-color-contrast';
+
+function ColorSequenceInfo(
+  { colorSequence, colorShift = 0}
+  : {
+    colorSequence: ColorSequenceArray,
+    colorShift?: number,
+  }
+) {
+  const shiftedColorSequence = shiftedColorSequenceArray(colorSequence, colorShift)
+  return <section> {/* todo: this should be a div but I need to change styling of divs in fieldsets*/}
+    <pre>total color sequence length: {totalColorSequenceLength(colorSequence)}</pre>
+    <pre>shifted color sequence: 
+    {shiftedColorSequence.map(({color, length}, index) => (
+      <span
+        key={`color${index}`}
+        className='color-preview'
+        style={ {
+          background: color,
+          color: fontColorContrast(color),
+        }}
+      >
+        {length}
+      </span>
+    ))}
+    </pre>
+  </section>
+}
+
+export default ColorSequenceInfo

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -4,13 +4,9 @@ import TogglableColorPicker from './inputs/TogglableColorPicker'
 import IntegerInput from './inputs/Integer'
 import { Color, SwatchConfig } from './types'
 import { getRandomNotWhiteColor, totalColorSequenceLength } from './color'
+import { mod } from './numberHelpers'
 
 type FormValue = keyof(SwatchConfig)
-
-function mod(n: number, m: number) {
-  // because native JS % operator chokes on negatives
-  return ((n % m) + m) % m;
-}
 
 const defaultPickerColors = [
   "#d9073a",

--- a/src/Swatch.scss
+++ b/src/Swatch.scss
@@ -265,6 +265,6 @@ version of preview. Hopefully there will be a test of this diff at some point*/
 .squashed-swatch-container {
   display: flex;
   .swatch.compact-moss {
-    margin-left: -3px;
+    margin-right: -3px;
   }
 }

--- a/src/Swatch.scss
+++ b/src/Swatch.scss
@@ -89,6 +89,13 @@ version of preview. Hopefully there will be a test of this diff at some point*/
   @include interwovenStitch(28px, 14px, 1px, 0.5)
 }
 
+.swatch.compact-moss {
+  @include interwovenStitch(6px, 3px, 0px, 0.5);
+  .stitch {
+    border-width: 0;
+  }
+}
+
 .swatch.hdc {
   @include interwovenStitch(28px, 14px, 1px, 0.3)
 }
@@ -252,5 +259,12 @@ version of preview. Hopefully there will be a test of this diff at some point*/
       transform: rotateY(180deg) ;
       margin-left: -18px;
     }
+  }
+}
+
+.squashed-swatch-container {
+  display: flex;
+  .swatch.compact-moss {
+    margin-left: -3px;
   }
 }

--- a/src/Swatch.scss
+++ b/src/Swatch.scss
@@ -261,10 +261,3 @@ version of preview. Hopefully there will be a test of this diff at some point*/
     }
   }
 }
-
-.squashed-swatch-container {
-  display: flex;
-  .swatch.compact-moss {
-    margin-right: -3px;
-  }
-}

--- a/src/Swatch.tsx
+++ b/src/Swatch.tsx
@@ -10,6 +10,7 @@ type ClusterConfiguration = {
 }
 const clusterConfiguration:Record<StitchPattern, ClusterConfiguration> = { //Todo: make this a class of some sort?
   moss: {},
+  'compact-moss': {},
   unstyled: {},
   stacked: {},
   granny: {},

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -1,6 +1,78 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextStitchColorByIndex, isStringAColor, getRandomNotWhiteColor, totalColorSequenceLength, matchColorwayToColorSequence } from './color'
+import {
+  flatColorSequenceArray,
+  shiftedColorSequenceArray,
+  nextStitchColorByIndex,
+  isStringAColor,
+  getRandomNotWhiteColor,
+  totalColorSequenceLength,
+  matchColorwayToColorSequence,
+} from './color'
 import { ColorSequenceArray, ColorwayRecord } from './types'
+
+describe('flatColorSequenceArray', () => {
+  it('returns the flattened color sequence array without zero length colors', () => {
+    const colorSequence = [
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 0},
+      {color: "#ccc", length: 4},
+      {color: "#aaa", length: 3},
+      {color: "#ddd", length: 1}
+    ] as ColorSequenceArray
+
+    expect(flatColorSequenceArray(colorSequence)).toEqual([
+      '#aaa', '#aaa',
+      '#ccc', '#ccc', '#ccc', '#ccc',
+      '#aaa', '#aaa', '#aaa',
+      '#ddd',
+    ])
+  })
+})
+
+describe('shiftedColorSequenceArray', () => {
+  it('returns a shifted color sequence array with no zero lenght colors, depending on the shift', () => {
+    const colorSequence = [
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 0},
+      {color: "#ccc", length: 4},
+      {color: "#aaa", length: 3},
+      {color: "#ddd", length: 1}
+    ] as ColorSequenceArray
+
+    expect(shiftedColorSequenceArray(colorSequence, 0)).toEqual([
+      {color: "#aaa", length: 2},
+      {color: "#ccc", length: 4},
+      {color: "#aaa", length: 3},
+      {color: "#ddd", length: 1},
+    ])
+    expect(shiftedColorSequenceArray(colorSequence, 3)).toEqual([
+      {color: "#aaa", length: 2},
+      {color: "#ddd", length: 1},
+      {color: "#aaa", length: 2},
+      {color: "#ccc", length: 4},
+      {color: "#aaa", length: 1},
+    ])
+  })
+
+  it('works for negative or large numbers', () => {
+    const colorSequence = [
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 3},
+    ] as ColorSequenceArray
+
+    expect(shiftedColorSequenceArray(colorSequence, -1)).toEqual([
+      {color: "#aaa", length: 1},
+      {color: "#bbb", length: 3},
+      {color: "#aaa", length: 1},
+    ])
+
+    expect(shiftedColorSequenceArray(colorSequence, 6)).toEqual([
+      {color: "#bbb", length: 1},
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 2},
+    ])
+  })
+})
 
 describe('nextStitchByColorIndex', () => {
   it('gives the next stitch color in the sequence', () => {

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -47,11 +47,11 @@ describe('shiftedColorSequenceArray', () => {
     ])
 
     expect(shiftedColorSequenceArray(colorSequence, 3)).toEqual([
-      {color: "#aaa", length: 2},
+      {color: "#ccc", length: 3},
+      {color: "#aaa", length: 3},
       {color: "#ddd", length: 1},
       {color: "#aaa", length: 2},
-      {color: "#ccc", length: 4},
-      {color: "#aaa", length: 1},
+      {color: "#ccc", length: 1},
     ])
   })
 
@@ -63,9 +63,8 @@ describe('shiftedColorSequenceArray', () => {
     ] as ColorSequenceArray
 
     expect(shiftedColorSequenceArray(colorSequence, 2)).toEqual([
-      {color: "#ccc", length: 2},
+      {color: "#ccc", length: 4},
       {color: "#aaa", length: 2},
-      {color: "#ccc", length: 2},
     ])
 
     expect(colorSequence).toEqual([
@@ -82,15 +81,15 @@ describe('shiftedColorSequenceArray', () => {
     ] as ColorSequenceArray
 
     expect(shiftedColorSequenceArray(colorSequence, -1)).toEqual([
-      {color: "#aaa", length: 1},
-      {color: "#bbb", length: 3},
-      {color: "#aaa", length: 1},
-    ])
-
-    expect(shiftedColorSequenceArray(colorSequence, 6)).toEqual([
       {color: "#bbb", length: 1},
       {color: "#aaa", length: 2},
       {color: "#bbb", length: 2},
+    ])
+
+    expect(shiftedColorSequenceArray(colorSequence, 6)).toEqual([
+      {color: "#aaa", length: 1},
+      {color: "#bbb", length: 3},
+      {color: "#aaa", length: 1},
     ])
   })
 })

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -45,12 +45,33 @@ describe('shiftedColorSequenceArray', () => {
       {color: "#aaa", length: 3},
       {color: "#ddd", length: 1},
     ])
+
     expect(shiftedColorSequenceArray(colorSequence, 3)).toEqual([
       {color: "#aaa", length: 2},
       {color: "#ddd", length: 1},
       {color: "#aaa", length: 2},
       {color: "#ccc", length: 4},
       {color: "#aaa", length: 1},
+    ])
+  })
+
+  it('does not change color sequence', () => {
+    const colorSequence = [
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 0},
+      {color: "#ccc", length: 4},
+    ] as ColorSequenceArray
+
+    expect(shiftedColorSequenceArray(colorSequence, 2)).toEqual([
+      {color: "#ccc", length: 2},
+      {color: "#aaa", length: 2},
+      {color: "#ccc", length: 2},
+    ])
+
+    expect(colorSequence).toEqual([
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 0},
+      {color: "#ccc", length: 4},
     ])
   })
 

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -136,6 +136,15 @@ describe('nextStitchByColorIndex', () => {
     expect(nextStitchColorByIndex(10, config, {colorShift: 3})).toBe("#0f0")
     expect(nextStitchColorByIndex(11, config, {colorShift: 3})).toBe("#00f")
   })
+  it('works with negative colorShift', () => {
+    const config = [
+      {color: "#f00", length: 2},
+      {color: "#0f0", length: 3},
+      {color: "#00f", length: 4}
+    ] as ColorSequenceArray
+
+    expect(nextStitchColorByIndex(0, config, {colorShift: -3})).toBe("#00f")
+  })
 })
 
 describe('isStringAColor', () => {

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,9 +1,30 @@
 import { Color, ColorInSequence, ColorSequenceArray, ColorwayRecord } from './types'
 import { DeepReadonly } from 'ts-essentials'
+import { mod } from './numberHelpers'
+
+export function flatColorSequenceArray(colorSequence : ColorSequenceArray) : Array<Color> {
+  return colorSequence.reduce((ary : Array<Color>, conf: ColorInSequence) : Array<Color> => ary.concat(new Array(conf.length).fill(conf.color)), []);
+}
 
 export function nextStitchColorByIndex(i : number, colorSequence : ColorSequenceArray, { colorShift } = { colorShift: 0 } ):Color {
-  const flatColorSequenceArray = colorSequence.reduce((ary : Array<Color>, conf: ColorInSequence) : Array<Color> => ary.concat(new Array(conf.length).fill(conf.color)), []);
-  return flatColorSequenceArray[(i + colorShift) % flatColorSequenceArray.length];
+  const flattened = flatColorSequenceArray(colorSequence)
+  return flattened[(i + colorShift) % flattened.length];
+}
+
+export function shiftedColorSequenceArray(colorSequence : ColorSequenceArray, colorShift: number) : ColorSequenceArray {
+  const flattened = flatColorSequenceArray(colorSequence)
+  const shift = mod(colorShift, totalColorSequenceLength(colorSequence))
+  flattened.unshift(...flattened.splice(-shift, shift))
+  const shiftedColorSequence = flattened.reduce((newArray: ColorSequenceArray, color : Color) => {
+    const last = newArray.slice(-1)[0]
+    if(last && last.color === color) {
+      last.length += 1
+    } else {
+      newArray.push({color: color, length: 1})
+    }
+    return newArray
+  }, [])
+  return shiftedColorSequence
 }
 
 export function isStringAColor(s: string) : boolean {

--- a/src/color.ts
+++ b/src/color.ts
@@ -14,7 +14,7 @@ export function nextStitchColorByIndex(i : number, colorSequence : ColorSequence
 export function shiftedColorSequenceArray(colorSequence : ColorSequenceArray, colorShift: number) : ColorSequenceArray {
   const flattened = flatColorSequenceArray(colorSequence)
   const shift = mod(colorShift, totalColorSequenceLength(colorSequence))
-  flattened.unshift(...flattened.splice(-shift, shift))
+  flattened.push(...flattened.splice(0, shift))
   const shiftedColorSequence = flattened.reduce((newArray: ColorSequenceArray, color : Color) => {
     const last = newArray.slice(-1)[0]
     if(last && last.color === color) {

--- a/src/color.ts
+++ b/src/color.ts
@@ -8,7 +8,7 @@ export function flatColorSequenceArray(colorSequence : ColorSequenceArray) : Arr
 
 export function nextStitchColorByIndex(i : number, colorSequence : ColorSequenceArray, { colorShift } = { colorShift: 0 } ):Color {
   const flattened = flatColorSequenceArray(colorSequence)
-  return flattened[(i + colorShift) % flattened.length];
+  return flattened[mod((i + colorShift), flattened.length)];
 }
 
 export function shiftedColorSequenceArray(colorSequence : ColorSequenceArray, colorShift: number) : ColorSequenceArray {

--- a/src/index.scss
+++ b/src/index.scss
@@ -16,10 +16,3 @@ main, footer {
   flex-direction: column;
   gap: 0.5em;
 }
-
-.squashed-swatch-container {
-  display: flex;
-  .swatch.moss {
-    margin-left: -15px;
-  }
-}

--- a/src/index.scss
+++ b/src/index.scss
@@ -16,3 +16,10 @@ main, footer {
   flex-direction: column;
   gap: 0.5em;
 }
+
+.squashed-swatch-container {
+  display: flex;
+  .swatch.moss {
+    margin-left: -15px;
+  }
+}

--- a/src/numberHelpers.test.ts
+++ b/src/numberHelpers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { mod } from './numberHelpers'
+
+describe('mod', () => {
+  it('returns the correct positive number for a big negative number', () => {
+    expect(mod(-33, 10)).toEqual(7)
+  })
+  it('returns the correct positive number for a negative number', () => {
+    expect(mod(-3, 10)).toEqual(7)
+  })
+  it('returns the correct number for a small positive number', () => {
+    expect(mod(7, 10)).toEqual(7)
+  })
+  it('returns the correct number for a big positive number', () => {
+    expect(mod(53, 10)).toEqual(3)
+  })
+  it('works when the second number is not ten', () => {
+    expect(mod(7, 5)).toEqual(2)
+  })
+})

--- a/src/numberHelpers.ts
+++ b/src/numberHelpers.ts
@@ -1,0 +1,4 @@
+export function mod(n: number, m: number) {
+  // because native JS % operator chokes on negatives
+  return ((n % m) + m) % m;
+}

--- a/src/projects/DiffusionScarf.scss
+++ b/src/projects/DiffusionScarf.scss
@@ -1,0 +1,15 @@
+.squashed-swatch-container {
+  display: flex;
+  .swatchWrapper {
+    cursor: pointer;
+    &.flip {
+      transform: rotateY(180deg)
+    }
+    &.selected {
+      background-color: #bbf;
+    }
+  }
+  .swatch.compact-moss {
+    margin-right: -3px;
+  }
+}

--- a/src/projects/DiffusionScarf.test.tsx
+++ b/src/projects/DiffusionScarf.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from "react-router-dom";
+import DiffusionScarf from './DiffusionScarf'
+
+describe('DoloresParkTote', () => {
+  it('renders the component with a swatch in it', () => {
+    render(
+      <MemoryRouter>
+        <DiffusionScarf />
+      </MemoryRouter>
+    )
+    expect(screen.getAllByTestId("swatch").length).toBeGreaterThan(1)
+  })
+})
+

--- a/src/projects/DiffusionScarf.test.tsx
+++ b/src/projects/DiffusionScarf.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from "react-router-dom";
 import DiffusionScarf from './DiffusionScarf'
 
-describe('DoloresParkTote', () => {
+describe('DiffusionScarf', () => {
   it('renders the component with a swatch in it', () => {
     render(
       <MemoryRouter>

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -8,19 +8,24 @@ import { useState } from "react";
 
 function DiffusionScarf() {
   const colorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
+    {color: accent, length: 3},
     {color: '#000', length: 17},
-    {color: accent, length: 3}
   ])
   const oddColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
-    {color: '#000', length: 18},
-    {color: accent, length: 3}
-  ])
-  const stretchedColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
-    {color: '#000', length: 17},
     {color: accent, length: 3},
     {color: '#000', length: 18},
-    {color: accent, length: 3}
   ])
+  const generateStaggeredSequence = (cc : Color, mc : Color, ccLength : number, seqLength : number) => ([
+    { color: cc, length: ccLength },
+    { color: mc, length: (Math.ceil(seqLength/2) - ccLength)},
+    { color: cc, length: ccLength },
+    { color: mc, length: (Math.floor(seqLength/2) - ccLength)},
+  ])
+
+  const stretchedColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => {
+    const stretchedLength = 20 + 21
+    return generateStaggeredSequence(accent, '#000', 3, stretchedLength)
+  }
 
   const neonPurple = '#e100ff' as Color
   const neonPink = '#FF00A0' as Color
@@ -33,71 +38,70 @@ function DiffusionScarf() {
   const initialPanelConfigs = [
     {
       stitchesPerRow: 10,
-      colorShift: 17,
+      colorShift: 0,
       colorSequence: colorSequenceWithAccent(neonOrange),
       flip: true,
     },
     {
       stitchesPerRow: 20,
-      colorShift: 16,
+      colorShift: 20,
       colorSequence: stretchedColorSequenceWithAccent(neonPink)
 
     },
     {
       stitchesPerRow: 19,
-      colorShift: 14,
+      colorShift: 17,
       colorSequence: colorSequenceWithAccent(neonPurple)
     },
     {
       stitchesPerRow: 18,
-      colorShift: 17,
+      colorShift: 20,
       colorSequence: colorSequenceWithAccent(neonBlue)
     },
     {
       stitchesPerRow: 16,
-      colorShift: 17,
+      colorShift: 20,
       colorSequence: colorSequenceWithAccent(neonGreen),
       flip: true,
     },
     {
       stitchesPerRow: 16,
-      colorShift: 0,
+      colorShift: 3,
       colorSequence: oddColorSequenceWithAccent(neonYellow)
     },
     {
       stitchesPerRow: 15,
-      colorShift: 17,
+      colorShift: 20,
       colorSequence: colorSequenceWithAccent(neonGreen)
     },
     {
       stitchesPerRow: 14,
-      colorShift: 20,
+      colorShift: 2,
       colorSequence: oddColorSequenceWithAccent(neonBlue),
       flip: true,
     },
     {
       stitchesPerRow: 12,
-      colorShift: 17,
+      colorShift: 20,
       colorSequence: colorSequenceWithAccent(neonPurple)
     },
     {
       stitchesPerRow: 12,
-      colorShift: 18,
+      colorShift: 0,
       colorSequence: oddColorSequenceWithAccent(neonPink)
     },
     {
       stitchesPerRow: 11,
-      colorShift: 13,
+      colorShift: 16,
       colorSequence: colorSequenceWithAccent(neonOrange)
     },
     {
       stitchesPerRow: 11,
-      colorShift: 2, // 12, 12', 2, 2'
+      colorShift: 5, // 15, 15', 5, 5'
       colorSequence: oddColorSequenceWithAccent(neonYellow),
       flip: true,
     },
   ]
-
 
   const [selectedSwatchIndex, setSelectedSwatchIndex] = useState(0)
   const [panelConfigs, setPanelConfigs] = useState(initialPanelConfigs)
@@ -115,24 +119,24 @@ function DiffusionScarf() {
     nextPanelConfigs[selectedSwatchIndex].flip = newFlip
     setPanelConfigs(nextPanelConfigs)
   }
-  const selectedAccentColorLength = selectedSwatchConfig.colorSequence[1].length
-  const selectedMainColorLength = selectedSwatchConfig.colorSequence[0].length
+  const selectedAccentColorLength = selectedSwatchConfig.colorSequence[0].length
+  const selectedMainColorLength = selectedSwatchConfig.colorSequence[1].length
   const setSelectedColorLengthsBasedOnAccent = (newAccentLength: number) => {
     const nextPanelConfigs = [...panelConfigs]
     const prevSequence = selectedSwatchConfig.colorSequence
     const seqLength = totalColorSequenceLength(prevSequence)
     if(prevSequence.length === 2) {
       nextPanelConfigs[selectedSwatchIndex].colorSequence = [
-        { color: prevSequence[0].color, length: seqLength - newAccentLength},
-        { color: prevSequence[1].color, length: newAccentLength},
+        { color: prevSequence[0].color, length: newAccentLength},
+        { color: prevSequence[1].color, length: seqLength - newAccentLength},
       ]
     } else if(prevSequence.length === 4) {
-      nextPanelConfigs[selectedSwatchIndex].colorSequence = [
-        { color: prevSequence[0].color, length: Math.floor(seqLength/2) - newAccentLength},
-        { color: prevSequence[1].color, length: newAccentLength},
-        { color: prevSequence[0].color, length: Math.ceil(seqLength/2) - newAccentLength},
-        { color: prevSequence[1].color, length: newAccentLength},
-      ]
+      nextPanelConfigs[selectedSwatchIndex].colorSequence = generateStaggeredSequence(
+        prevSequence[0].color,
+        prevSequence[1].color,
+        newAccentLength,
+        seqLength
+      )
     }
     setPanelConfigs(nextPanelConfigs)
   }

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -113,6 +113,17 @@ function DiffusionScarf() {
     nextPanelConfigs[selectedSwatchIndex].flip = newFlip
     setPanelConfigs(nextPanelConfigs)
   }
+  const selectedAccentColorLength = panelConfigs[selectedSwatchIndex].colorSequence[1].length
+  const setSelectedColorLengthsBasedOnAccent = (newAccentLength: number) => {
+    const nextPanelConfigs = [...panelConfigs]
+    const prevSequence = panelConfigs[selectedSwatchIndex].colorSequence
+    const seqLength = totalColorSequenceLength(prevSequence)
+    nextPanelConfigs[selectedSwatchIndex].colorSequence = [
+      { color: prevSequence[0].color, length: seqLength - newAccentLength},
+      { color: prevSequence[1].color, length: newAccentLength},
+    ]
+    setPanelConfigs(nextPanelConfigs)
+  }
 
   const sharedConfig = {
     numberOfRows: 30,
@@ -141,20 +152,29 @@ function DiffusionScarf() {
           e.preventDefault();
         }}>
         <fieldset>
-        <IntegerInput
-          label="Color shift:"
-          title={"color shift"}
-          name="colorShift"
-          value={selectedColorShift}
-          setValue={setSelectedColorShift}
-        />
-        <CheckboxInput
-          label="Flip preview"
-          title="flip preview"
-          name="flipPreview"
-          value={selectedFlipPreview}
-          setValue={setSelectedFlipPreview}
-        />
+          <IntegerInput
+            label="Color shift:"
+            title="Start the swatch this many stitches into your color sequence"
+            name="colorShift"
+            value={selectedColorShift}
+            setValue={setSelectedColorShift}
+            withTooltip={true}
+          />
+          <IntegerInput
+            label="Accent Color Length:"
+            title="The color sequence length will always be the same, but if you have more stitches of your accent color you can change this"
+            name="accentColorLength"
+            value={selectedAccentColorLength}
+            setValue={setSelectedColorLengthsBasedOnAccent}
+            withTooltip={true}
+          />
+          <CheckboxInput
+            label="Flip preview"
+            title="flip the small version of the swatch"
+            name="flipPreview"
+            value={selectedFlipPreview}
+            setValue={setSelectedFlipPreview}
+          />
           <pre>
             stitches per row: {panelConfigs[selectedSwatchIndex].stitchesPerRow}<br/>
             color sequence length: {totalColorSequenceLength(panelConfigs[selectedSwatchIndex].colorSequence)}

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -1,11 +1,13 @@
 import Swatch from '../Swatch';
 import { StitchPattern, Color, ColorSequenceArray } from '../types'
-import IntegerInput from '../inputs/Integer'
-import { useState } from "react";
+/*
+ import IntegerInput from '../inputs/Integer'
+ import { useState } from "react";
+ */
 import { totalColorSequenceLength } from '../color'
 
 function DiffusionScarf() {
-  const [mainColorShift, setMainColorShift] = useState(0)
+  // const [mainColorShift, setMainColorShift] = useState(0)
   const colorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
     {color: '#000', length: 17},
     {color: accent, length: 3}
@@ -20,15 +22,10 @@ function DiffusionScarf() {
     {color: '#000', length: 18},
     {color: accent, length: 3}
   ])
-  const swallowedColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
-    {color: '#000', length: 14},
-    {color: accent, length: 4},
-    {color: '#000', length: 13},
-    {color: accent, length: 4}
-  ])
   const sharedConfig = {
     numberOfRows: 30,
-    colorShift: mainColorShift,
+    // colorShift: mainColorShift,
+    colorShift: 0,
     staggerLengths: false,
   }
 
@@ -112,12 +109,12 @@ function DiffusionScarf() {
       <div className="squashed-swatch-container">
         {
           panelConfigs.map((specificConfig, index) =>{
-            let style = {transform: ""}
+            const style = {transform: ""}
             if(specificConfig.flip) {
               style.transform = "rotateY(180deg)"
             }
             return (
-              <div style={style}>
+              <div style={style} key={`compactChart${index}`}>
                 <a href={`#chart${index}`}>
                   <Swatch {...sharedConfig} stitchPattern={StitchPattern.compactMoss} {...specificConfig} />
                 </a>
@@ -137,7 +134,7 @@ function DiffusionScarf() {
         */}
       <div className="container">
         {panelConfigs.map((specificConfig, index) => (
-          <div>
+          <div key={`chart${index}`}>
             <a id={`chart${index}`}>
               <pre>
                 stitches per row: {specificConfig.stitchesPerRow}<br/>

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -101,7 +101,9 @@ function DiffusionScarf() {
 
   const [selectedSwatchIndex, setSelectedSwatchIndex] = useState(0)
   const [panelConfigs, setPanelConfigs] = useState(initialPanelConfigs)
-  const selectedColorShift = panelConfigs[selectedSwatchIndex].colorShift
+  const selectedSwatchConfig = panelConfigs[selectedSwatchIndex]
+
+  const selectedColorShift = selectedSwatchConfig.colorShift
   const setSelectedColorShift = (newShift: number) => {
     const nextPanelConfigs = [...panelConfigs]
     nextPanelConfigs[selectedSwatchIndex].colorShift = newShift
@@ -113,15 +115,25 @@ function DiffusionScarf() {
     nextPanelConfigs[selectedSwatchIndex].flip = newFlip
     setPanelConfigs(nextPanelConfigs)
   }
-  const selectedAccentColorLength = panelConfigs[selectedSwatchIndex].colorSequence[1].length
+  const selectedAccentColorLength = selectedSwatchConfig.colorSequence[1].length
+  const selectedMainColorLength = selectedSwatchConfig.colorSequence[0].length
   const setSelectedColorLengthsBasedOnAccent = (newAccentLength: number) => {
     const nextPanelConfigs = [...panelConfigs]
-    const prevSequence = panelConfigs[selectedSwatchIndex].colorSequence
+    const prevSequence = selectedSwatchConfig.colorSequence
     const seqLength = totalColorSequenceLength(prevSequence)
-    nextPanelConfigs[selectedSwatchIndex].colorSequence = [
-      { color: prevSequence[0].color, length: seqLength - newAccentLength},
-      { color: prevSequence[1].color, length: newAccentLength},
-    ]
+    if(prevSequence.length === 2) {
+      nextPanelConfigs[selectedSwatchIndex].colorSequence = [
+        { color: prevSequence[0].color, length: seqLength - newAccentLength},
+        { color: prevSequence[1].color, length: newAccentLength},
+      ]
+    } else if(prevSequence.length === 4) {
+      nextPanelConfigs[selectedSwatchIndex].colorSequence = [
+        { color: prevSequence[0].color, length: Math.floor(seqLength/2) - newAccentLength},
+        { color: prevSequence[1].color, length: newAccentLength},
+        { color: prevSequence[0].color, length: Math.ceil(seqLength/2) - newAccentLength},
+        { color: prevSequence[1].color, length: newAccentLength},
+      ]
+    }
     setPanelConfigs(nextPanelConfigs)
   }
 
@@ -152,20 +164,24 @@ function DiffusionScarf() {
           e.preventDefault();
         }}>
         <fieldset>
-          <IntegerInput
-            label="Color shift:"
-            title="Start the swatch this many stitches into your color sequence"
-            name="colorShift"
-            value={selectedColorShift}
-            setValue={setSelectedColorShift}
-            withTooltip={true}
-          />
+          <pre>
+            total color sequence length (varies per swatch): {totalColorSequenceLength(selectedSwatchConfig.colorSequence)}
+          </pre>
+          { selectedSwatchConfig.colorSequence.length === 2 ?  <pre>main color length: {selectedMainColorLength}</pre> : <pre>color sequence: {JSON.stringify(selectedSwatchConfig.colorSequence)}</pre>}
           <IntegerInput
             label="Accent Color Length:"
             title="The color sequence length will always be the same, but if you have more stitches of your accent color you can change this"
             name="accentColorLength"
             value={selectedAccentColorLength}
             setValue={setSelectedColorLengthsBasedOnAccent}
+            withTooltip={true}
+          />
+          <IntegerInput
+            label="Color shift:"
+            title="Start the swatch this many stitches into your color sequence"
+            name="colorShift"
+            value={selectedColorShift}
+            setValue={setSelectedColorShift}
             withTooltip={true}
           />
           <CheckboxInput
@@ -176,8 +192,7 @@ function DiffusionScarf() {
             setValue={setSelectedFlipPreview}
           />
           <pre>
-            stitches per row: {panelConfigs[selectedSwatchIndex].stitchesPerRow}<br/>
-            color sequence length: {totalColorSequenceLength(panelConfigs[selectedSwatchIndex].colorSequence)}
+            stitches per row in this swatch: {panelConfigs[selectedSwatchIndex].stitchesPerRow}<br/>
           </pre>
         </fieldset>
       </form>

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -29,7 +29,7 @@ function DiffusionScarf() {
     numberOfRows: 30,
     colorShift: mainColorShift,
     staggerLengths: false,
-    stitchPattern: StitchPattern.moss,
+    stitchPattern: StitchPattern.compactMoss,
   }
 
   const neonPurple = '#e100ff' as Color
@@ -41,46 +41,6 @@ function DiffusionScarf() {
 
   return (
     <div className="container">
-      <IntegerInput
-        label="Color shift:"
-        title={"color shift"}
-        name="colorShift"
-        value={mainColorShift}
-        setValue={setMainColorShift}
-      />
-      {/*
-      <p>combined, no really random ones</p>
-      <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={19} colorShift={4} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={1} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={1} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={1} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={6} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorShift={6} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={5} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={3} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={0} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={0} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-      </div>
-      combined alternate
-      <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={11} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={19} colorShift={13} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={3} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={4} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={3} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={10} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorShift={5} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={19} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={13} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={3} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={7} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-      </div>
-        */}
-      combined alternate 2
       <div className="squashed-swatch-container">
         <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
         <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={11} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
@@ -95,49 +55,6 @@ function DiffusionScarf() {
         <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={3} colorSequence={colorSequenceWithAccent(neonOrange)}/>
         <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={7} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
       </div>
-      {/*
-      <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={20} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={19} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-      </div>
-      <p>odd</p>
-      <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={20} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={19} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-      </div>
-      <p>combined</p>
-      <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={19} colorShift={3} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={1} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonGreen)}/> {//can be even or odd, very random }
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={1} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={6} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorShift={6} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonPurple)}/> {//can be even or odd, very random}
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-      </div>
-    */}
     </div>
   );
 }

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -173,6 +173,7 @@ function DiffusionScarf() {
             value={selectedAccentColorLength}
             setValue={setSelectedColorLengthsBasedOnAccent}
             withTooltip={true}
+            validator={IntegerInput.validators.nonNegative}
           />
           <IntegerInput
             label="Color shift:"

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -45,7 +45,7 @@ function DiffusionScarf() {
     },
     {
       stitchesPerRow: 20,
-      colorShift: 20,
+      colorShift: 0,
       colorSequence: stretchedColorSequenceWithAccent(neonPink)
 
     },
@@ -56,12 +56,12 @@ function DiffusionScarf() {
     },
     {
       stitchesPerRow: 18,
-      colorShift: 20,
+      colorShift: 0,
       colorSequence: colorSequenceWithAccent(neonBlue)
     },
     {
       stitchesPerRow: 16,
-      colorShift: 20,
+      colorShift: 0,
       colorSequence: colorSequenceWithAccent(neonGreen),
       flip: true,
     },
@@ -72,7 +72,7 @@ function DiffusionScarf() {
     },
     {
       stitchesPerRow: 15,
-      colorShift: 20,
+      colorShift: 0,
       colorSequence: colorSequenceWithAccent(neonGreen)
     },
     {
@@ -83,7 +83,7 @@ function DiffusionScarf() {
     },
     {
       stitchesPerRow: 12,
-      colorShift: 20,
+      colorShift: 0,
       colorSequence: colorSequenceWithAccent(neonPurple)
     },
     {

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -98,9 +98,8 @@ function DiffusionScarf() {
     },
     {
       stitchesPerRow: 11,
-      colorShift: 5, // 15, 15', 5, 5'
+      colorShift: 15, // 15, 15', 5, 5'
       colorSequence: oddColorSequenceWithAccent(neonYellow),
-      flip: true,
     },
   ]
 

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -98,7 +98,7 @@ function DiffusionScarf() {
     },
     {
       stitchesPerRow: 11,
-      //colorShift: 2, // 12, 12', 2, 2'
+      colorShift: 2, // 12, 12', 2, 2'
       colorSequence: oddColorSequenceWithAccent(neonYellow),
       flip: true,
     },

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -1,0 +1,213 @@
+import Swatch from '../Swatch';
+import { StitchPattern, Color, ColorSequenceArray } from '../types'
+import IntegerInput from '../inputs/Integer'
+import { useState } from "react";
+
+function DiffusionScarf() {
+  const [mainColorShift, setMainColorShift] = useState(0)
+  const colorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
+    {color: '#000', length: 14},
+    {color: accent, length: 4}
+  ])
+  const oddColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
+    {color: '#000', length: 15},
+    {color: accent, length: 4}
+  ])
+  const stretchedColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
+    {color: '#000', length: 14},
+    {color: accent, length: 4},
+    {color: '#000', length: 15},
+    {color: accent, length: 4}
+  ])
+  const swallowedColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
+    {color: '#000', length: 14},
+    {color: accent, length: 4},
+    {color: '#000', length: 13},
+    {color: accent, length: 4}
+  ])
+  const sharedConfig = {
+    numberOfRows: 30,
+    colorShift: mainColorShift,
+    staggerLengths: false,
+    stitchPattern: StitchPattern.moss,
+  }
+
+  const neonPurple = '#e100ff' as Color
+  const neonPink = '#FF00A0' as Color
+  const neonOrange = '#ff9904' as Color
+  const neonYellow = '#EBFF04' as Color
+  const neonGreen = '#79FF04' as Color
+  const neonBlue = '#04FFFF' as Color
+
+  return (
+    <div className="container">
+      <IntegerInput
+        label="Color shift:"
+        title={"color shift"}
+        name="colorShift"
+        value={mainColorShift}
+        setValue={setMainColorShift}
+      />
+      {/*
+      <p>1</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={20} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={19} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={stretchedColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={swallowedColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+      </div>
+      <p>2</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={2} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={stretchedColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+      </div>
+        */}
+      <p>3</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={20} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={19} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={stretchedColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={2} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={swallowedColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        {/*<Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonBlue)}/>*/}
+      </div>
+      <p>4</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={5} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={8} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={swallowedColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonPink)}/>
+      </div>
+      <p>yellow middle</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={5} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={8} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={swallowedColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+      </div>
+      <p>yellow first</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={5} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={8} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={swallowedColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+      </div>
+      <p>5</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={3} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={6} colorShift={1} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={5} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={4} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+      </div>
+      <p>6</p>
+      <div className="squashed-swatch-container">
+        {/*
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+          */}
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={6} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={6} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={5} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+      </div>
+      <p>7</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={5} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9}  colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={6} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={5} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={4} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={3}  colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+      </div>
+      <p>8</p>
+      <div className="squashed-swatch-container">
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={3} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={6} colorShift={1} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={6} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={5} colorSequence={colorSequenceWithAccent(neonPink)}/>
+      </div>
+    </div>
+  );
+}
+
+export default DiffusionScarf;
+

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -2,6 +2,7 @@ import Swatch from '../Swatch';
 import { StitchPattern, Color, ColorSequenceArray } from '../types'
 import IntegerInput from '../inputs/Integer'
 import { useState } from "react";
+import { totalColorSequenceLength } from '../color'
 
 function DiffusionScarf() {
   const [mainColorShift, setMainColorShift] = useState(0)
@@ -29,7 +30,6 @@ function DiffusionScarf() {
     numberOfRows: 30,
     colorShift: mainColorShift,
     staggerLengths: false,
-    stitchPattern: StitchPattern.compactMoss,
   }
 
   const neonPurple = '#e100ff' as Color
@@ -39,21 +39,36 @@ function DiffusionScarf() {
   const neonGreen = '#79FF04' as Color
   const neonBlue = '#04FFFF' as Color
 
+  const panelConfigs = [
+    { stitchesPerRow: 10, colorShift: 7, colorSequence: colorSequenceWithAccent(neonOrange) },
+    { stitchesPerRow: 20, colorShift: 11, colorSequence: stretchedColorSequenceWithAccent(neonPink) },
+    { stitchesPerRow: 19, colorShift: 4, colorSequence: colorSequenceWithAccent(neonPurple) },
+    { stitchesPerRow: 18, colorShift: 13, colorSequence: colorSequenceWithAccent(neonBlue) },
+    { stitchesPerRow: 16, colorShift: 1, colorSequence: colorSequenceWithAccent(neonGreen) },
+    { stitchesPerRow: 16, colorShift: 3, colorSequence: oddColorSequenceWithAccent(neonYellow) },
+    { stitchesPerRow: 15, colorShift: 17, colorSequence: colorSequenceWithAccent(neonGreen) },
+    { stitchesPerRow: 14, colorShift: 5,  colorSequence: oddColorSequenceWithAccent(neonBlue) },
+    { stitchesPerRow: 12, colorShift: 5,  colorSequence: colorSequenceWithAccent(neonPurple) },
+    { stitchesPerRow: 12, colorShift: 13, colorSequence: oddColorSequenceWithAccent(neonPink) },
+    { stitchesPerRow: 11, colorShift: 3,  colorSequence: colorSequenceWithAccent(neonOrange) },
+    { stitchesPerRow: 11, colorShift: 7,  colorSequence: oddColorSequenceWithAccent(neonYellow) },
+  ]
+
   return (
     <div className="container">
       <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={11} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={19} colorShift={4} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={13} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={1} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={3} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={17} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorShift={5} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={5} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={13} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={3} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={7} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        {panelConfigs.map((specificConfig) => <Swatch {...sharedConfig} stitchPattern={StitchPattern.compactMoss} {...specificConfig} />)}
+      </div>
+      <div className="container">
+        {panelConfigs.map((specificConfig) => (
+          <div>
+            <pre>
+              stitches per row: {specificConfig.stitchesPerRow}<br/>
+              color sequence length: {totalColorSequenceLength(specificConfig.colorSequence)}
+            </pre>
+            <Swatch className='numbered' {...sharedConfig} stitchPattern={StitchPattern.moss} {...specificConfig} />
+          </div>
+          ))}
       </div>
     </div>
   );

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -1,3 +1,4 @@
+import './DiffusionScarf.scss';
 import Swatch from '../Swatch';
 import { StitchPattern, Color, ColorSequenceArray } from '../types'
 import { totalColorSequenceLength } from '../color'
@@ -150,12 +151,9 @@ function DiffusionScarf() {
       <div className="squashed-swatch-container">
         {
           panelConfigs.map((specificConfig, index) =>{
-            const style = { transform: "", cursor: 'pointer'}
-            if(specificConfig.flip) {
-              style.transform = "rotateY(180deg)"
-            }
+            const classes = ['swatchWrapper', specificConfig.flip ? 'flip' : '', index === selectedSwatchIndex ? 'selected' : '']
             return (
-              <div style={style} key={`compactChart${index}`} onClick={() => setSelectedSwatchIndex(index)}>
+              <div className={classes.join(' ')} key={`compactChart${index}`} onClick={() => setSelectedSwatchIndex(index)}>
                 <Swatch {...sharedConfig} stitchPattern={StitchPattern.compactMoss} {...specificConfig} />
               </div>
             )

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -40,32 +40,110 @@ function DiffusionScarf() {
   const neonBlue = '#04FFFF' as Color
 
   const panelConfigs = [
-    { stitchesPerRow: 10, colorShift: 7, colorSequence: colorSequenceWithAccent(neonOrange) },
-    { stitchesPerRow: 20, colorShift: 11, colorSequence: stretchedColorSequenceWithAccent(neonPink) },
-    { stitchesPerRow: 19, colorShift: 4, colorSequence: colorSequenceWithAccent(neonPurple) },
-    { stitchesPerRow: 18, colorShift: 13, colorSequence: colorSequenceWithAccent(neonBlue) },
-    { stitchesPerRow: 16, colorShift: 1, colorSequence: colorSequenceWithAccent(neonGreen) },
-    { stitchesPerRow: 16, colorShift: 3, colorSequence: oddColorSequenceWithAccent(neonYellow) },
-    { stitchesPerRow: 15, colorShift: 17, colorSequence: colorSequenceWithAccent(neonGreen) },
-    { stitchesPerRow: 14, colorShift: 5,  colorSequence: oddColorSequenceWithAccent(neonBlue) },
-    { stitchesPerRow: 12, colorShift: 5,  colorSequence: colorSequenceWithAccent(neonPurple) },
-    { stitchesPerRow: 12, colorShift: 13, colorSequence: oddColorSequenceWithAccent(neonPink) },
-    { stitchesPerRow: 11, colorShift: 3,  colorSequence: colorSequenceWithAccent(neonOrange) },
-    { stitchesPerRow: 11, colorShift: 7,  colorSequence: oddColorSequenceWithAccent(neonYellow) },
+    {
+      stitchesPerRow: 10,
+      colorShift: 17,
+      colorSequence: colorSequenceWithAccent(neonOrange),
+      flip: true,
+    },
+    {
+      stitchesPerRow: 20,
+      colorShift: 16,
+      colorSequence: stretchedColorSequenceWithAccent(neonPink)
+
+    },
+    {
+      stitchesPerRow: 19,
+      colorShift: 14,
+      colorSequence: colorSequenceWithAccent(neonPurple)
+    },
+    {
+      stitchesPerRow: 18,
+      colorShift: 17,
+      colorSequence: colorSequenceWithAccent(neonBlue)
+    },
+    {
+      stitchesPerRow: 16,
+      colorShift: 17,
+      colorSequence: colorSequenceWithAccent(neonGreen),
+      flip: true,
+    },
+    {
+      stitchesPerRow: 16,
+      colorShift: 0,
+      colorSequence: oddColorSequenceWithAccent(neonYellow)
+    },
+    {
+      stitchesPerRow: 15,
+      colorShift: 17,
+      colorSequence: colorSequenceWithAccent(neonGreen)
+    },
+    {
+      stitchesPerRow: 14,
+      colorShift: 20,
+      colorSequence: oddColorSequenceWithAccent(neonBlue),
+      flip: true,
+    },
+    {
+      stitchesPerRow: 12,
+      colorShift: 17,
+      colorSequence: colorSequenceWithAccent(neonPurple)
+    },
+    {
+      stitchesPerRow: 12,
+      colorShift: 18,
+      colorSequence: oddColorSequenceWithAccent(neonPink)
+    },
+    {
+      stitchesPerRow: 11,
+      colorShift: 13,
+      colorSequence: colorSequenceWithAccent(neonOrange)
+    },
+    {
+      stitchesPerRow: 11,
+      //colorShift: 2, // 12, 12', 2, 2'
+      colorSequence: oddColorSequenceWithAccent(neonYellow),
+      flip: true,
+    },
   ]
 
   return (
     <div className="container">
       <div className="squashed-swatch-container">
-        {panelConfigs.map((specificConfig) => <Swatch {...sharedConfig} stitchPattern={StitchPattern.compactMoss} {...specificConfig} />)}
+        {
+          panelConfigs.map((specificConfig, index) =>{
+            let style = {transform: ""}
+            if(specificConfig.flip) {
+              style.transform = "rotateY(180deg)"
+            }
+            return (
+              <div style={style}>
+                <a href={`#chart${index}`}>
+                  <Swatch {...sharedConfig} stitchPattern={StitchPattern.compactMoss} {...specificConfig} />
+                </a>
+              </div>
+            )
+          })
+        }
       </div>
+      {/*
+      <IntegerInput
+        label="Color shift:"
+        title={"color shift"}
+        name="colorShift"
+        value={mainColorShift}
+        setValue={setMainColorShift}
+      />
+        */}
       <div className="container">
-        {panelConfigs.map((specificConfig) => (
+        {panelConfigs.map((specificConfig, index) => (
           <div>
-            <pre>
-              stitches per row: {specificConfig.stitchesPerRow}<br/>
-              color sequence length: {totalColorSequenceLength(specificConfig.colorSequence)}
-            </pre>
+            <a id={`chart${index}`}>
+              <pre>
+                stitches per row: {specificConfig.stitchesPerRow}<br/>
+                color sequence length: {totalColorSequenceLength(specificConfig.colorSequence)}
+              </pre>
+            </a>
             <Swatch className='numbered' {...sharedConfig} stitchPattern={StitchPattern.moss} {...specificConfig} />
           </div>
           ))}

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -6,18 +6,18 @@ import { useState } from "react";
 function DiffusionScarf() {
   const [mainColorShift, setMainColorShift] = useState(0)
   const colorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
-    {color: '#000', length: 14},
-    {color: accent, length: 4}
+    {color: '#000', length: 17},
+    {color: accent, length: 3}
   ])
   const oddColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
-    {color: '#000', length: 15},
-    {color: accent, length: 4}
+    {color: '#000', length: 18},
+    {color: accent, length: 3}
   ])
   const stretchedColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
-    {color: '#000', length: 14},
-    {color: accent, length: 4},
-    {color: '#000', length: 15},
-    {color: accent, length: 4}
+    {color: '#000', length: 17},
+    {color: accent, length: 3},
+    {color: '#000', length: 18},
+    {color: accent, length: 3}
   ])
   const swallowedColorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
     {color: '#000', length: 14},
@@ -49,162 +49,95 @@ function DiffusionScarf() {
         setValue={setMainColorShift}
       />
       {/*
-      <p>1</p>
+      <p>combined, no really random ones</p>
       <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={20} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={19} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={stretchedColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={swallowedColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={19} colorShift={4} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={1} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={1} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={1} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={6} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorShift={6} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={5} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={3} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={0} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={0} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
       </div>
-      <p>2</p>
+      combined alternate
       <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={2} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={stretchedColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={11} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={19} colorShift={13} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={3} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={4} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={3} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={10} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorShift={5} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={19} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={13} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={3} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={7} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
       </div>
         */}
-      <p>3</p>
+      combined alternate 2
       <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={20} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={19} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={stretchedColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={2} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={swallowedColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        {/*<Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonBlue)}/>*/}
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={11} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={19} colorShift={4} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={13} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={1} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={3} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={17} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorShift={5} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={5} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={13} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={3} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorShift={7} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
       </div>
-      <p>4</p>
+      {/*
       <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={5} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={8} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={swallowedColorSequenceWithAccent(neonYellow)}/>
         <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonPink)}/>
-      </div>
-      <p>yellow middle</p>
-      <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={5} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={8} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={swallowedColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-      </div>
-      <p>yellow first</p>
-      <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={5} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={8} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={swallowedColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-      </div>
-      <p>5</p>
-      <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={3} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={colorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={6} colorShift={1} colorSequence={colorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={5} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={4} colorSequence={colorSequenceWithAccent(neonGreen)}/>
-      </div>
-      <p>6</p>
-      <div className="squashed-swatch-container">
-        {/*
+        <Swatch {...sharedConfig} stitchesPerRow={20} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={19} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={colorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorSequence={colorSequenceWithAccent(neonGreen)}/>
         <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-          */}
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={6} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={6} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={5} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={colorSequenceWithAccent(neonOrange)}/>
       </div>
-      <p>7</p>
+      <p>odd</p>
       <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={5} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={15} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9}  colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={6} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={5} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={4} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={3}  colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={20} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={19} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
       </div>
-      <p>8</p>
+      <p>combined</p>
       <div className="squashed-swatch-container">
-        <Swatch {...sharedConfig} stitchesPerRow={14} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorShift={4} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={10} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorShift={3} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={9} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={colorSequenceWithAccent(neonPink)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={8} colorSequence={oddColorSequenceWithAccent(neonPurple)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={colorSequenceWithAccent(neonBlue)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={7} colorSequence={oddColorSequenceWithAccent(neonGreen)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={6} colorShift={1} colorSequence={colorSequenceWithAccent(neonYellow)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={6} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
-        <Swatch {...sharedConfig} stitchesPerRow={5} colorSequence={colorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={10} colorShift={7} colorSequence={colorSequenceWithAccent(neonOrange)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={20} colorShift={10} colorSequence={stretchedColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={19} colorShift={3} colorSequence={colorSequenceWithAccent(neonPurple)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={18} colorShift={1} colorSequence={colorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={17} colorSequence={colorSequenceWithAccent(neonGreen)}/> {//can be even or odd, very random }
+        <Swatch {...sharedConfig} stitchesPerRow={16} colorShift={1} colorSequence={oddColorSequenceWithAccent(neonYellow)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={15} colorShift={6} colorSequence={colorSequenceWithAccent(neonGreen)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={14} colorShift={6} colorSequence={oddColorSequenceWithAccent(neonBlue)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={13} colorSequence={oddColorSequenceWithAccent(neonPurple)}/> {//can be even or odd, very random}
+        <Swatch {...sharedConfig} stitchesPerRow={12} colorSequence={oddColorSequenceWithAccent(neonPink)}/>
+        <Swatch {...sharedConfig} stitchesPerRow={11} colorSequence={oddColorSequenceWithAccent(neonOrange)}/>
       </div>
+    */}
     </div>
   );
 }

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -1,12 +1,12 @@
 import Swatch from '../Swatch';
 import { StitchPattern, Color, ColorSequenceArray } from '../types'
 import { totalColorSequenceLength } from '../color'
-// import IntegerInput from '../inputs/Integer'
+import IntegerInput from '../inputs/Integer'
+import CheckboxInput from '../inputs/Checkbox'
 import { useState } from "react";
 
 
 function DiffusionScarf() {
-  const [selectedSwatchIndex, setSelectedSwatchIndex] = useState(0)
   const colorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
     {color: '#000', length: 17},
     {color: accent, length: 3}
@@ -21,12 +21,6 @@ function DiffusionScarf() {
     {color: '#000', length: 18},
     {color: accent, length: 3}
   ])
-  const sharedConfig = {
-    numberOfRows: 30,
-    // colorShift: mainColorShift,
-    colorShift: 0,
-    staggerLengths: false,
-  }
 
   const neonPurple = '#e100ff' as Color
   const neonPink = '#FF00A0' as Color
@@ -35,7 +29,8 @@ function DiffusionScarf() {
   const neonGreen = '#79FF04' as Color
   const neonBlue = '#04FFFF' as Color
 
-  const panelConfigs = [
+
+  const initialPanelConfigs = [
     {
       stitchesPerRow: 10,
       colorShift: 17,
@@ -103,6 +98,27 @@ function DiffusionScarf() {
     },
   ]
 
+
+  const [selectedSwatchIndex, setSelectedSwatchIndex] = useState(0)
+  const [panelConfigs, setPanelConfigs] = useState(initialPanelConfigs)
+  const selectedColorShift = panelConfigs[selectedSwatchIndex].colorShift
+  const setSelectedColorShift = (newShift: number) => {
+    const nextPanelConfigs = [...panelConfigs]
+    nextPanelConfigs[selectedSwatchIndex].colorShift = newShift
+    setPanelConfigs(nextPanelConfigs)
+  }
+  const selectedFlipPreview = !!(panelConfigs[selectedSwatchIndex].flip)
+  const setSelectedFlipPreview = (newFlip: boolean) => {
+    const nextPanelConfigs = [...panelConfigs]
+    nextPanelConfigs[selectedSwatchIndex].flip = newFlip
+    setPanelConfigs(nextPanelConfigs)
+  }
+
+  const sharedConfig = {
+    numberOfRows: 30,
+    staggerLengths: false,
+  }
+
   return (
     <div className="container">
       <div className="squashed-swatch-container">
@@ -120,23 +136,33 @@ function DiffusionScarf() {
           })
         }
       </div>
-      {/*
-      <IntegerInput
-        label="Color shift:"
-        title={"color shift"}
-        name="colorShift"
-        value={mainColorShift}
-        setValue={setMainColorShift}
-      />
-        */}
-      <div className="container">
-        <div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}>
+        <fieldset>
+        <IntegerInput
+          label="Color shift:"
+          title={"color shift"}
+          name="colorShift"
+          value={selectedColorShift}
+          setValue={setSelectedColorShift}
+        />
+        <CheckboxInput
+          label="Flip preview"
+          title="flip preview"
+          name="flipPreview"
+          value={selectedFlipPreview}
+          setValue={setSelectedFlipPreview}
+        />
           <pre>
             stitches per row: {panelConfigs[selectedSwatchIndex].stitchesPerRow}<br/>
             color sequence length: {totalColorSequenceLength(panelConfigs[selectedSwatchIndex].colorSequence)}
           </pre>
-          <Swatch className='numbered' {...sharedConfig} stitchPattern={StitchPattern.moss} {...panelConfigs[selectedSwatchIndex]} />
-        </div>
+        </fieldset>
+      </form>
+      <div className="container">
+        <Swatch className='numbered' {...sharedConfig} stitchPattern={StitchPattern.moss} {...panelConfigs[selectedSwatchIndex]} />
       </div>
     </div>
   );

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -1,13 +1,12 @@
 import Swatch from '../Swatch';
 import { StitchPattern, Color, ColorSequenceArray } from '../types'
-/*
- import IntegerInput from '../inputs/Integer'
- import { useState } from "react";
- */
 import { totalColorSequenceLength } from '../color'
+// import IntegerInput from '../inputs/Integer'
+import { useState } from "react";
+
 
 function DiffusionScarf() {
-  // const [mainColorShift, setMainColorShift] = useState(0)
+  const [selectedSwatchIndex, setSelectedSwatchIndex] = useState(0)
   const colorSequenceWithAccent = (accent : Color) : ColorSequenceArray => ([
     {color: '#000', length: 17},
     {color: accent, length: 3}
@@ -109,15 +108,13 @@ function DiffusionScarf() {
       <div className="squashed-swatch-container">
         {
           panelConfigs.map((specificConfig, index) =>{
-            const style = {transform: ""}
+            const style = { transform: "", cursor: 'pointer'}
             if(specificConfig.flip) {
               style.transform = "rotateY(180deg)"
             }
             return (
-              <div style={style} key={`compactChart${index}`}>
-                <a href={`#chart${index}`}>
-                  <Swatch {...sharedConfig} stitchPattern={StitchPattern.compactMoss} {...specificConfig} />
-                </a>
+              <div style={style} key={`compactChart${index}`} onClick={() => setSelectedSwatchIndex(index)}>
+                <Swatch {...sharedConfig} stitchPattern={StitchPattern.compactMoss} {...specificConfig} />
               </div>
             )
           })
@@ -133,17 +130,13 @@ function DiffusionScarf() {
       />
         */}
       <div className="container">
-        {panelConfigs.map((specificConfig, index) => (
-          <div key={`chart${index}`}>
-            <a id={`chart${index}`}>
-              <pre>
-                stitches per row: {specificConfig.stitchesPerRow}<br/>
-                color sequence length: {totalColorSequenceLength(specificConfig.colorSequence)}
-              </pre>
-            </a>
-            <Swatch className='numbered' {...sharedConfig} stitchPattern={StitchPattern.moss} {...specificConfig} />
-          </div>
-          ))}
+        <div>
+          <pre>
+            stitches per row: {panelConfigs[selectedSwatchIndex].stitchesPerRow}<br/>
+            color sequence length: {totalColorSequenceLength(panelConfigs[selectedSwatchIndex].colorSequence)}
+          </pre>
+          <Swatch className='numbered' {...sharedConfig} stitchPattern={StitchPattern.moss} {...panelConfigs[selectedSwatchIndex]} />
+        </div>
       </div>
     </div>
   );

--- a/src/projects/DiffusionScarf.tsx
+++ b/src/projects/DiffusionScarf.tsx
@@ -3,6 +3,7 @@ import { StitchPattern, Color, ColorSequenceArray } from '../types'
 import { totalColorSequenceLength } from '../color'
 import IntegerInput from '../inputs/Integer'
 import CheckboxInput from '../inputs/Checkbox'
+import ColorSequenceInfo from '../ColorSequenceInfo'
 import { useState } from "react";
 
 
@@ -120,7 +121,6 @@ function DiffusionScarf() {
     setPanelConfigs(nextPanelConfigs)
   }
   const selectedAccentColorLength = selectedSwatchConfig.colorSequence[0].length
-  const selectedMainColorLength = selectedSwatchConfig.colorSequence[1].length
   const setSelectedColorLengthsBasedOnAccent = (newAccentLength: number) => {
     const nextPanelConfigs = [...panelConfigs]
     const prevSequence = selectedSwatchConfig.colorSequence
@@ -168,10 +168,7 @@ function DiffusionScarf() {
           e.preventDefault();
         }}>
         <fieldset>
-          <pre>
-            total color sequence length (varies per swatch): {totalColorSequenceLength(selectedSwatchConfig.colorSequence)}
-          </pre>
-          { selectedSwatchConfig.colorSequence.length === 2 ?  <pre>main color length: {selectedMainColorLength}</pre> : <pre>color sequence: {JSON.stringify(selectedSwatchConfig.colorSequence)}</pre>}
+          <ColorSequenceInfo colorSequence={selectedSwatchConfig.colorSequence} colorShift={selectedSwatchConfig.colorShift}/>
           <IntegerInput
             label="Accent Color Length:"
             title="The color sequence length will always be the same, but if you have more stitches of your accent color you can change this"

--- a/src/projects/Preview.tsx
+++ b/src/projects/Preview.tsx
@@ -47,6 +47,7 @@ export default function Preview() {
       <StitchPatternPreview stitchPattern={StitchPattern.unstyled} title="unstyled stitch pattern"/>
       <StitchPatternPreview stitchPattern={StitchPattern.stacked}/>
       <StitchPatternPreview stitchPattern={StitchPattern.moss}/>
+      <StitchPatternPreview stitchPattern={StitchPattern.compactMoss}/>
       <StitchPatternPreview stitchPattern={StitchPattern.hdc} notes="Probably needs a rename, called hdc based on the amian hat"/>
       <StitchPatternPreview stitchPattern={StitchPattern.granny}/>
       <StitchPatternPreview stitchPattern={StitchPattern.shell} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export enum StitchPattern {
   ripple = "ripple",
   vstitchCluster = "vstitchCluster",
   ablockCluster = "ablockCluster",
+  compactMoss = "compact-moss",
 }
 
 export type Color = `#${string}`;

--- a/src/wrapper.tsx
+++ b/src/wrapper.tsx
@@ -9,6 +9,7 @@ import LogoOption from './projects/LogoOption'
 import StretchLengths from './projects/StretchLengths'
 import Parallax from './projects/Parallax'
 import DoloresParkTote from './projects/DoloresParkTote'
+import DiffusionScarf from './projects/DiffusionScarf'
 import './index.scss'
 import {
   createBrowserRouter,
@@ -43,6 +44,10 @@ const router = createBrowserRouter([
   {
     path: "/dolores-park-tote",
     element: <DoloresParkTote/>
+  },
+  {
+    path: "/diffusion-scarf",
+    element: <DiffusionScarf/>
   },
   {
     path: "/",


### PR DESCRIPTION
<img width="1120" alt="Screenshot 2024-03-31 at 6 06 37 PM" src="https://github.com/alenia/planned-pooling/assets/699890/e052ca5a-b0b7-47b4-8a18-a8cec24ddece">


* Add diffusion scarf endpoint:
  - has tiny preview
  -  when you click a preview image, it pulls up the swatch for that box
  - you can change the accent color length for the selected swatch which automatically changes the main color length
  - you can flip the preview of the currently selected swatch
  - you can change the color shift of the currently selected swatch
* Create ColorSequenceInfo component that prints out shifted color sequence (it's ugly or else it would go in app now)
* Add compact moss stitch for tiny scarf preview
* Fix negative color shift (was showing blank stitches before)
* move mod to number helpers and test it