### PR TITLE
Make color swallowing logic come from swatchMatrix instead of a css hack

### DIFF
--- a/src/Swatch.scss
+++ b/src/Swatch.scss
@@ -65,13 +65,6 @@ version of preview. Hopefully there will be a test of this diff at some point*/
       margin-left: $stitchWidth + $spacing;
     }
   }
-  &.colorSwallowed.staggered {
-    .crow:nth-child(2n+1) {
-      .stitch:first-child {
-        display: none;
-      }
-    }
-  }
 
   .stitch {
     box-sizing: border-box;

--- a/src/Swatch.test.tsx
+++ b/src/Swatch.test.tsx
@@ -324,7 +324,7 @@ describe('Swatch', () => {
           expect(row1stitches[4]).toHaveStyle('background-color: #000')
       })
 
-      it('removes a stitch between each even row and odd row when colors are swallowed', () => {
+      it('skips a stitch color after each even row when colors are swallowed', () => {
           render(
             <Swatch
               colorSequence={[

--- a/src/Swatch.test.tsx
+++ b/src/Swatch.test.tsx
@@ -187,7 +187,7 @@ describe('Swatch', () => {
           expect(swatch.children[0].children[0]).toHaveClass('stitch')
       })
 
-      it('secretly alternates row lengths when color is swallowed', () => {
+      it('does not alternate row lengths when colors are swallowed', () => {
           render(
             <Swatch
               colorSequence={[
@@ -204,9 +204,9 @@ describe('Swatch', () => {
 
           const swatch = screen.getByTestId("swatch")
           expect(swatch.children.length, 'should have correct numberOfRows').toEqual(4)
-          expect(swatch.children[0].children.length, 'first row should have correct number of stitches').toEqual(6)
+          expect(swatch.children[0].children.length, 'first row should have correct number of stitches').toEqual(5)
           expect(swatch.children[1].children.length, 'second row should have correct number of stitches').toEqual(5)
-          expect(swatch.children[2].children.length, 'third row should have correct number of stitches').toEqual(6)
+          expect(swatch.children[2].children.length, 'third row should have correct number of stitches').toEqual(5)
           expect(swatch.children[3].children.length, 'fourth row should have correct number of stitches').toEqual(5)
 
           expect(swatch.children[0]).toHaveClass('crow')
@@ -324,7 +324,7 @@ describe('Swatch', () => {
           expect(row1stitches[4]).toHaveStyle('background-color: #000')
       })
 
-      it('has an extra (hidden by css) stitch at the beginning of each odd row when stitches are swallowed', () => {
+      it('removes a stitch between each even row and odd row when colors are swallowed', () => {
           render(
             <Swatch
               colorSequence={[
@@ -349,18 +349,23 @@ describe('Swatch', () => {
 
           const swatch = screen.getByTestId("swatch")
           const row0stitches = swatch.children[0].children;
-          expect(row0stitches[0]).toHaveStyle('background-color: #900')
-          expect(row0stitches[1]).toHaveStyle('background-color: #000')
-          expect(row0stitches[2]).toHaveStyle('background-color: #100')
-          expect(row0stitches[3]).toHaveStyle('background-color: #200')
-          expect(row0stitches[4]).toHaveStyle('background-color: #300')
-          expect(row0stitches[5]).toHaveStyle('background-color: #400')
+          expect(row0stitches[0]).toHaveStyle('background-color: #000')
+          expect(row0stitches[1]).toHaveStyle('background-color: #100')
+          expect(row0stitches[2]).toHaveStyle('background-color: #200')
+          expect(row0stitches[3]).toHaveStyle('background-color: #300')
+          expect(row0stitches[4]).toHaveStyle('background-color: #400')
           const row1stitches = swatch.children[1].children;
           expect(row1stitches[0]).toHaveStyle('background-color: #500')
           expect(row1stitches[1]).toHaveStyle('background-color: #600')
           expect(row1stitches[2]).toHaveStyle('background-color: #700')
           expect(row1stitches[3]).toHaveStyle('background-color: #800')
           expect(row1stitches[4]).toHaveStyle('background-color: #900')
+          const row2stitches = swatch.children[2].children;
+          expect(row2stitches[0]).toHaveStyle('background-color: #100')
+          expect(row2stitches[1]).toHaveStyle('background-color: #200')
+          expect(row2stitches[2]).toHaveStyle('background-color: #300')
+          expect(row2stitches[3]).toHaveStyle('background-color: #400')
+          expect(row2stitches[4]).toHaveStyle('background-color: #500')
       })
 
       it('color stretches with correct row lengths and colors', () => {

--- a/src/Swatch.tsx
+++ b/src/Swatch.tsx
@@ -130,10 +130,7 @@ function Swatch(
   ]
 
   if(clustered) {
-
-    const computedColorShift = staggerLengths && staggerType === 'colorSwallowed' ? colorShift - 1 : colorShift
-
-    const nextColor = (index: number) => nextStitchColorByIndex(index, colorSequence, {colorShift: computedColorShift})
+    const nextColor = (index: number) => nextStitchColorByIndex(index, colorSequence, {colorShift: colorShift})
     return <div data-testid="swatch" className={classNames.join(' ')}>
       <ClusteredSwatch
         clustersPerRow={stitchesPerRow}

--- a/src/swatchHelpers.test.ts
+++ b/src/swatchHelpers.test.ts
@@ -171,14 +171,15 @@ describe('swatchMatrix', () => {
         {color: '#eee', length: 1},
       ] as ColorSequenceArray,
         stitchesPerRow: 4,
-        numberOfRows: 3,
+        numberOfRows: 4,
         colorShift: 0,
         staggerLengths: true,
         staggerType: 'colorSwallowed'
       })).toEqual([
-        ["#eee","#aaa","#bbb","#ccc","#ddd"],
-               ["#eee","#aaa","#bbb","#ccc"],
-        ["#ddd","#eee","#aaa","#bbb","#ccc"]
+        ["#aaa","#bbb","#ccc","#ddd"],
+        ["#eee","#aaa","#bbb","#ccc"],
+        ["#eee","#aaa","#bbb","#ccc"],
+        ["#ddd","#eee","#aaa","#bbb"],
       ])
   })
   it('stretches stitches', () => {
@@ -377,7 +378,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         staggerType: 'colorSwallowed'
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
-        ["#ddd","#ccc","#bbb","#aaa"],
+        ["#ccc","#bbb","#aaa","#eee"],
         ["#eee","#aaa","#bbb","#ccc"]
       ])
   })

--- a/src/swatchHelpers.ts
+++ b/src/swatchHelpers.ts
@@ -16,9 +16,9 @@ export function swatchMatrix({
     return staggerType === typeName
   }
   const output = [] as Array<Array<Color>>
-  let startingIndex = staggeredWithType('colorSwallowed') ? colorShift - 1 : colorShift;
+  let startingIndex = colorShift;
   for(let i = 0; i < numberOfRows; i++) {
-    const stitchesInThisRow = ((staggeredWithType('normal') || staggeredWithType('colorSwallowed')) && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
+    const stitchesInThisRow = (staggeredWithType('normal') && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
 
     const nextSlice = circularSlice(flattenedColorSequence, startingIndex, stitchesInThisRow) as Array<Color>
 
@@ -26,6 +26,8 @@ export function swatchMatrix({
 
     if(staggeredWithType('colorStretched') && i % 2 === 1) {
       startingIndex += stitchesInThisRow - 1
+    } else if(staggeredWithType('colorSwallowed') && i % 2 === 1) {
+      startingIndex += stitchesInThisRow + 1
     } else {
       startingIndex += stitchesInThisRow
     }
@@ -57,7 +59,7 @@ export function swatchMatrixWithReversedEvenRows({ //TODO: This is the (unused) 
 
     if(staggeredWithType('colorStretched') && i % 2 === 1) {
       startingIndex += stitchesInThisRow - 1
-    } else if(staggeredWithType('colorSwallowed') && i % 2 === 0) {
+    } else if(staggeredWithType('colorSwallowed') && i % 2 === 1) {
       startingIndex += stitchesInThisRow + 1
     } else {
       startingIndex += stitchesInThisRow


### PR DESCRIPTION
Previously color swallowing was done using a `display: none` on the first child of the empty row. This hack was adding some cruft and a confusing invisible stitch that wasn't shown on every stitch pattern.
For a parity check, I took a screenshot of my local dolores park tote vs the one in prod, set both to color swallowing.
 
<img width="1375" alt="Screenshot 2025-01-17 at 11 12 59 PM" src="https://github.com/user-attachments/assets/f70381e6-c1c5-4092-9ee9-5b2dba793120" />

I also removed an artifact untested unused line of code that was adding the ghost stitch to clustered swatches. There aren't any clustered swatches being used externally and also I never used color swallowing with clustered swatches. I also never styled clustered swatches with swallowed stitches since I think it wouldn't actually work.