### PR TITLE
Use a matrix to build the clustered swatches as well

### DIFF
--- a/src/Swatch.tsx
+++ b/src/Swatch.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react'
-import { nextStitchColorByIndex } from './colorSequenceHelpers'
 import { swatchMatrix, clusteredSwatchMatrix } from './swatchHelpers'
-import { StitchPattern, Color, ColorSequenceArray, StandardSwatchConfig } from './types'
+import { StitchPattern, Color, ColorSequenceArray } from './types'
 import './Swatch.scss'
 
 type ClusterConfiguration = {

--- a/src/Swatch.tsx
+++ b/src/Swatch.tsx
@@ -1,27 +1,17 @@
 import { ReactNode } from 'react'
 import { swatchMatrix, clusteredSwatchMatrix } from './swatchHelpers'
-import { StitchPattern, Color, ColorSequenceArray } from './types'
+import { StitchPattern, Color, ColorSequenceArray, ClusterConfiguration } from './types'
 import './Swatch.scss'
 
-type ClusterConfiguration = {
-    stitchCount?: number,
-    prepend?: boolean ,
-    append?: boolean,
-}
-type PresentClusterConfiguration = {
-    stitchCount: number,
-    prepend?: boolean ,
-    append?: boolean,
-}
-const clusterConfiguration:Record<StitchPattern, ClusterConfiguration> = { //Todo: make this a class of some sort?
-  moss: {},
-  'compact-moss': {},
-  unstyled: {},
-  stacked: {},
-  granny: {},
-  hdc: {},
-  shell: {},
-  'v-stitch': {},
+const clusterConfiguration:Record<StitchPattern, (ClusterConfiguration | null)> = { //Todo: make this a class of some sort?
+  moss: null,
+  'compact-moss': null,
+  unstyled: null,
+  stacked: null,
+  granny: null,
+  hdc: null,
+  shell: null,
+  'v-stitch': null,
   jasmine: {
     stitchCount: 3,
     prepend: true
@@ -65,19 +55,18 @@ function Swatch(
   }
 ) {
   const clusterConfig = clusterConfiguration[stitchPattern];
-  const clustered = !!clusterConfig.stitchCount;
 
   const classNames = [
     className,
     'swatch',
     stitchPattern,
-    clustered ? 'clustered' : '',
+    clusterConfig ? 'clustered' : '',
     staggerLengths ? 'staggered' : '',
     staggerType
   ]
 
-  if(clustered) {
-    const matrix = clusteredSwatchMatrix({colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths}, clusterConfig as PresentClusterConfiguration)
+  if(clusterConfig) {
+    const matrix = clusteredSwatchMatrix({colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths}, clusterConfig)
     return <div data-testid="swatch" className={classNames.join(' ')}>
       {matrix.map((rowArray, i) => (
         <Crow key={i}>

--- a/src/Swatch.tsx
+++ b/src/Swatch.tsx
@@ -9,6 +9,11 @@ type ClusterConfiguration = {
     prepend?: boolean ,
     append?: boolean,
 }
+type PresentClusterConfiguration = {
+    stitchCount: number,
+    prepend?: boolean ,
+    append?: boolean,
+}
 const clusterConfiguration:Record<StitchPattern, ClusterConfiguration> = { //Todo: make this a class of some sort?
   moss: {},
   'compact-moss': {},
@@ -47,49 +52,8 @@ function Stitch ({color} : { color: Color}) {
   return <div className="stitch" style={{backgroundColor: color}}/>
 }
 
-function ClusteredSwatch({
-  colorSequence,
-  stitchesPerRow,
-  numberOfRows,
-  colorShift,
-  staggerLengths,
-  staggerType,
-  clusterConfig,
-} : StandardSwatchConfig & {staggerType: 'normal' | 'colorStretched' | 'colorSwallowed', clusterConfig: ClusterConfiguration}) {
-  const matrix = clusteredSwatchMatrix({colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths}, clusterConfig)
-  return matrix.map((rowArray, i) => (
-    <Crow key={i}>
-      { rowArray.map((clusterArray, j) => (
-        <Cluster key ={j}>
-          { clusterArray.map((color, k) => (
-            <Stitch key={k} color={color}/>
-          )) }
-        </Cluster>
-      )) }
-    </Crow>
-  ))
-}
-
-function StandardSwatch({
-  colorSequence,
-  stitchesPerRow,
-  numberOfRows,
-  colorShift,
-  staggerLengths,
-  staggerType
-} : StandardSwatchConfig & {staggerType: 'normal' | 'colorStretched' | 'colorSwallowed'}) {
-  const matrix = swatchMatrix({colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, staggerType})
-  return matrix.map((rowArray, i) => (
-    <Crow key={i}>
-      { rowArray.map((color, i) => (
-        <Stitch key={i} color={color}/>
-      )) }
-    </Crow>
-  ))
-}
-
 function Swatch(
-  { colorSequence, stitchesPerRow, stitchPattern, numberOfRows = 40, colorShift = 0, staggerLengths = false, staggerType, className}
+  { colorSequence, stitchesPerRow, stitchPattern, numberOfRows = 40, colorShift = 0, staggerLengths = false, staggerType = "normal", className}
   : {
     colorSequence: ColorSequenceArray,
     stitchesPerRow: number,
@@ -114,27 +78,30 @@ function Swatch(
   ]
 
   if(clustered) {
+    const matrix = clusteredSwatchMatrix({colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths}, clusterConfig as PresentClusterConfiguration)
     return <div data-testid="swatch" className={classNames.join(' ')}>
-      <ClusteredSwatch
-        clusterConfig={clusterConfig}
-        stitchesPerRow={stitchesPerRow}
-        numberOfRows={numberOfRows}
-        staggerLengths={staggerLengths}
-        staggerType={staggerType || 'normal'}
-        colorSequence={colorSequence}
-        colorShift={colorShift}
-      />
+      {matrix.map((rowArray, i) => (
+        <Crow key={i}>
+          { rowArray.map((clusterArray, j) => (
+            <Cluster key ={j}>
+              { clusterArray.map((color, k) => (
+                <Stitch key={k} color={color}/>
+              )) }
+            </Cluster>
+          )) }
+        </Crow>
+      ))}
     </div>
   } else {
+    const matrix = swatchMatrix({colorSequence, stitchesPerRow, numberOfRows, colorShift, staggerLengths, staggerType})
     return <div data-testid="swatch" className={classNames.join(' ')}>
-      <StandardSwatch
-        stitchesPerRow={stitchesPerRow}
-        numberOfRows={numberOfRows}
-        staggerLengths={staggerLengths}
-        staggerType={staggerType || 'normal'}
-        colorSequence={colorSequence}
-        colorShift={colorShift}
-      />
+      { matrix.map((rowArray, i) => (
+        <Crow key={i}>
+          { rowArray.map((color, i) => (
+            <Stitch key={i} color={color}/>
+          )) }
+        </Crow>
+      ))}
     </div>
   }
 }

--- a/src/colorSequenceHelpers.test.ts
+++ b/src/colorSequenceHelpers.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import {
   flatColorSequenceArray,
   shiftedColorSequenceArray,
-  nextStitchColorByIndex,
   totalColorSequenceLength,
   matchColorwayToColorSequence,
   presetPickerColors,
@@ -90,59 +89,6 @@ describe('shiftedColorSequenceArray', () => {
       {color: "#bbb", length: 3},
       {color: "#aaa", length: 1},
     ])
-  })
-})
-
-describe('nextStitchByColorIndex', () => {
-  it('gives the next stitch color in the sequence', () => {
-    const config = [
-      {color: "#f00", length: 2},
-      {color: "#0f0", length: 3},
-      {color: "#00f", length: 4}
-    ] as ColorSequenceArray
-
-    expect(nextStitchColorByIndex(0, config, {colorShift: 0})).toBe("#f00")
-    expect(nextStitchColorByIndex(1, config, {colorShift: 0})).toBe("#f00")
-    expect(nextStitchColorByIndex(2, config, {colorShift: 0})).toBe("#0f0")
-    expect(nextStitchColorByIndex(3, config, {colorShift: 0})).toBe("#0f0")
-    expect(nextStitchColorByIndex(4, config, {colorShift: 0})).toBe("#0f0")
-    expect(nextStitchColorByIndex(5, config, {colorShift: 0})).toBe("#00f")
-    expect(nextStitchColorByIndex(6, config, {colorShift: 0})).toBe("#00f")
-    expect(nextStitchColorByIndex(7, config, {colorShift: 0})).toBe("#00f")
-    expect(nextStitchColorByIndex(8, config, {colorShift: 0})).toBe("#00f")
-    expect(nextStitchColorByIndex(9, config, {colorShift: 0})).toBe("#f00")
-    expect(nextStitchColorByIndex(10, config, {colorShift: 0})).toBe("#f00")
-    expect(nextStitchColorByIndex(11, config, {colorShift: 0})).toBe("#0f0")
-  })
-
-  it('gives the next stitch color in the sequence with a color shift when color shift is provided', () => {
-    const config = [
-      {color: "#f00", length: 2},
-      {color: "#0f0", length: 3},
-      {color: "#00f", length: 4}
-    ] as ColorSequenceArray
-
-    expect(nextStitchColorByIndex(0, config, {colorShift: 3})).toBe("#0f0")
-    expect(nextStitchColorByIndex(1, config, {colorShift: 3})).toBe("#0f0")
-    expect(nextStitchColorByIndex(2, config, {colorShift: 3})).toBe("#00f")
-    expect(nextStitchColorByIndex(3, config, {colorShift: 3})).toBe("#00f")
-    expect(nextStitchColorByIndex(4, config, {colorShift: 3})).toBe("#00f")
-    expect(nextStitchColorByIndex(5, config, {colorShift: 3})).toBe("#00f")
-    expect(nextStitchColorByIndex(6, config, {colorShift: 3})).toBe("#f00")
-    expect(nextStitchColorByIndex(7, config, {colorShift: 3})).toBe("#f00")
-    expect(nextStitchColorByIndex(8, config, {colorShift: 3})).toBe("#0f0")
-    expect(nextStitchColorByIndex(9, config, {colorShift: 3})).toBe("#0f0")
-    expect(nextStitchColorByIndex(10, config, {colorShift: 3})).toBe("#0f0")
-    expect(nextStitchColorByIndex(11, config, {colorShift: 3})).toBe("#00f")
-  })
-  it('works with negative colorShift', () => {
-    const config = [
-      {color: "#f00", length: 2},
-      {color: "#0f0", length: 3},
-      {color: "#00f", length: 4}
-    ] as ColorSequenceArray
-
-    expect(nextStitchColorByIndex(0, config, {colorShift: -3})).toBe("#00f")
   })
 })
 

--- a/src/colorSequenceHelpers.ts
+++ b/src/colorSequenceHelpers.ts
@@ -6,11 +6,6 @@ export function flatColorSequenceArray(colorSequence : ColorSequenceArray) : Arr
   return colorSequence.reduce((ary : Array<Color>, conf: ColorInSequence) : Array<Color> => ary.concat(new Array(conf.length).fill(conf.color)), []);
 }
 
-export function nextStitchColorByIndex(i : number, colorSequence : ColorSequenceArray, { colorShift } = { colorShift: 0 } ):Color {
-  const flattened = flatColorSequenceArray(colorSequence)
-  return flattened[mod((i + colorShift), flattened.length)];
-}
-
 export function shiftedColorSequenceArray(colorSequence : ColorSequenceArray, colorShift: number) : ColorSequenceArray {
   const flattened = flatColorSequenceArray(colorSequence)
   const shift = mod(colorShift, totalColorSequenceLength(colorSequence))

--- a/src/swatchHelpers.test.ts
+++ b/src/swatchHelpers.test.ts
@@ -3,6 +3,7 @@ import { ColorSequenceArray } from './types'
 import {
   swatchMatrix,
   swatchMatrixWithReversedEvenRows,
+  clusteredSwatchMatrix,
 } from './swatchHelpers'
 
 describe('swatchMatrix', () => {
@@ -402,6 +403,55 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         ["#ccc","#ddd","#eee","#aaa"],
         ["#eee","#ddd","#ccc","#bbb"],
         ["#eee","#aaa","#bbb","#ccc"],
+      ])
+  })
+})
+
+describe("clusteredSwatchMatrix", () => {
+  it('creates a matrix of color codes based on the color sequence and cluster configuration', () => {
+    expect(
+      clusteredSwatchMatrix({colorSequence: [
+        {color: '#aaa', length: 1},
+        {color: '#bbb', length: 1},
+        {color: '#ccc', length: 1},
+        {color: '#ddd', length: 1},
+        {color: '#eee', length: 1},
+      ] as ColorSequenceArray,
+        stitchesPerRow: 3, // Clusters per row in this case
+        numberOfRows: 3,
+        staggerLengths: false,
+        colorShift: 0,
+      }, {
+        stitchCount: 2,
+        prepend: false,
+        append: false
+      })).toEqual([
+        [["#aaa","#bbb"],["#ccc","#ddd"],["#eee","#aaa"]],
+        [["#bbb","#ccc"],["#ddd","#eee"],["#aaa","#bbb"]],
+        [["#ccc","#ddd"],["#eee","#aaa"],["#bbb","#ccc"]],
+      ])
+  })
+  it('prepends a single stitch cluster when prepend is selected', () => {
+    expect(
+      clusteredSwatchMatrix({colorSequence: [
+        {color: '#aaa', length: 1},
+        {color: '#bbb', length: 1},
+        {color: '#ccc', length: 1},
+        {color: '#ddd', length: 1},
+        {color: '#eee', length: 1},
+      ] as ColorSequenceArray,
+        stitchesPerRow: 3, // Clusters per row in this case
+        numberOfRows: 3,
+        staggerLengths: false,
+        colorShift: 0,
+      }, {
+        stitchCount: 2,
+        prepend: false,
+        append: false
+      })).toEqual([
+        [["#aaa","#bbb"],["#ccc","#ddd"],["#eee","#aaa"]],
+        [["#bbb","#ccc"],["#ddd","#eee"],["#aaa","#bbb"]],
+        [["#ccc","#ddd"],["#eee","#aaa"],["#bbb","#ccc"]],
       ])
   })
 })

--- a/src/swatchHelpers.test.ts
+++ b/src/swatchHelpers.test.ts
@@ -431,7 +431,7 @@ describe("clusteredSwatchMatrix", () => {
         [["#ccc","#ddd"],["#eee","#aaa"],["#bbb","#ccc"]],
       ])
   })
-  it('prepends a single stitch cluster when prepend is selected', () => {
+  it('prepends a single-stitch cluster when prepend is selected', () => {
     expect(
       clusteredSwatchMatrix({colorSequence: [
         {color: '#aaa', length: 1},
@@ -455,7 +455,7 @@ describe("clusteredSwatchMatrix", () => {
         [["#eee"],["#aaa","#bbb","#ccc"],["#ddd","#eee","#aaa"],["#bbb","#ccc","#ddd"],["#eee","#aaa","#bbb"]],
       ])
   })
-  it('appends a single stitch cluster when append is selected', () => {
+  it('appends a single-stitch cluster when append is selected', () => {
     expect(
       clusteredSwatchMatrix({colorSequence: [
         {color: '#aaa', length: 1},

--- a/src/swatchHelpers.test.ts
+++ b/src/swatchHelpers.test.ts
@@ -440,18 +440,43 @@ describe("clusteredSwatchMatrix", () => {
         {color: '#ddd', length: 1},
         {color: '#eee', length: 1},
       ] as ColorSequenceArray,
+        stitchesPerRow: 4, // Clusters per row in this case
+        numberOfRows: 4,
+        staggerLengths: false,
+        colorShift: 0,
+      }, {
+        stitchCount: 3,
+        prepend: true,
+        append: false
+      })).toEqual([
+        [["#aaa"],["#bbb","#ccc","#ddd"],["#eee","#aaa","#bbb"],["#ccc","#ddd","#eee"],["#aaa","#bbb","#ccc"]],
+        [["#ddd"],["#eee","#aaa","#bbb"],["#ccc","#ddd","#eee"],["#aaa","#bbb","#ccc"],["#ddd","#eee","#aaa"]],
+        [["#bbb"],["#ccc","#ddd","#eee"],["#aaa","#bbb","#ccc"],["#ddd","#eee","#aaa"],["#bbb","#ccc","#ddd"]],
+        [["#eee"],["#aaa","#bbb","#ccc"],["#ddd","#eee","#aaa"],["#bbb","#ccc","#ddd"],["#eee","#aaa","#bbb"]],
+      ])
+  })
+  it('appends a single stitch cluster when append is selected', () => {
+    expect(
+      clusteredSwatchMatrix({colorSequence: [
+        {color: '#aaa', length: 1},
+        {color: '#bbb', length: 1},
+        {color: '#ccc', length: 1},
+        {color: '#ddd', length: 1},
+        {color: '#eee', length: 1},
+      ] as ColorSequenceArray,
         stitchesPerRow: 3, // Clusters per row in this case
-        numberOfRows: 3,
+        numberOfRows: 4,
         staggerLengths: false,
         colorShift: 0,
       }, {
         stitchCount: 2,
         prepend: false,
-        append: false
+        append: true
       })).toEqual([
-        [["#aaa","#bbb"],["#ccc","#ddd"],["#eee","#aaa"]],
-        [["#bbb","#ccc"],["#ddd","#eee"],["#aaa","#bbb"]],
-        [["#ccc","#ddd"],["#eee","#aaa"],["#bbb","#ccc"]],
+        [["#aaa","#bbb"],["#ccc","#ddd"],["#eee","#aaa"],["#bbb"]],
+        [["#ccc","#ddd"],["#eee","#aaa"],["#bbb","#ccc"],["#ddd"]],
+        [["#eee","#aaa"],["#bbb","#ccc"],["#ddd","#eee"],["#aaa"]],
+        [["#bbb","#ccc"],["#ddd","#eee"],["#aaa","#bbb"],["#ccc"]]
       ])
   })
 })

--- a/src/swatchHelpers.ts
+++ b/src/swatchHelpers.ts
@@ -67,3 +67,41 @@ export function swatchMatrixWithReversedEvenRows({ //TODO: This is the (unused) 
   }
   return output
 }
+
+type ClusterConfiguration = { //TODO move to types.ts
+    stitchCount?: number,
+    prepend?: boolean ,
+    append?: boolean,
+}
+
+export function clusteredSwatchMatrix({
+  colorSequence,
+  stitchesPerRow,
+  numberOfRows,
+  colorShift,
+  staggerLengths,
+  //staggerType, clusters don't support stagger types yet
+} : StandardSwatchConfig, {
+  stitchCount
+} : ClusterConfiguration) : Array<Array<Array<Color>>>{
+  //Variable renames, deal with this later
+  const clustersPerRow = stitchesPerRow;
+  const stitchesPerCluster = stitchCount;
+
+  const flattenedColorSequence = flatColorSequenceArray(colorSequence)
+
+  const wholeOutput = [] as Array<Array<Array<Color>>>
+  let startingIndex = colorShift;
+  for(let i = 0; i < numberOfRows; i++) {
+    const clustersInThisRow = (staggerLengths && i % 2 === 0) ? clustersPerRow + 1 : clustersPerRow;
+    const rowOutput = [] as Array<Array<Color>>
+    for (let j = 0; j < clustersInThisRow; j++) {
+      const nextSlice = circularSlice(flattenedColorSequence, startingIndex, stitchesPerCluster) as Array<Color>
+      startingIndex += stitchesPerCluster
+      rowOutput.push(nextSlice)
+    }
+
+    wholeOutput.push(rowOutput)
+  }
+  return wholeOutput
+}

--- a/src/swatchHelpers.ts
+++ b/src/swatchHelpers.ts
@@ -1,4 +1,4 @@
-import { StandardSwatchConfig, Color } from './types'
+import { StandardSwatchConfig, Color, ClusterConfiguration } from './types'
 import { flatColorSequenceArray } from './colorSequenceHelpers'
 import { circularSlice } from './arrayHelpers'
 
@@ -66,12 +66,6 @@ export function swatchMatrixWithReversedEvenRows({ //TODO: This is the (unused) 
     }
   }
   return output
-}
-
-type ClusterConfiguration = { //TODO move to types.ts
-    stitchCount: number,
-    prepend?: boolean ,
-    append?: boolean,
 }
 
 export function clusteredSwatchMatrix({

--- a/src/swatchHelpers.ts
+++ b/src/swatchHelpers.ts
@@ -69,7 +69,7 @@ export function swatchMatrixWithReversedEvenRows({ //TODO: This is the (unused) 
 }
 
 type ClusterConfiguration = { //TODO move to types.ts
-    stitchCount?: number,
+    stitchCount: number,
     prepend?: boolean ,
     append?: boolean,
 }
@@ -81,12 +81,10 @@ export function clusteredSwatchMatrix({
   colorShift,
   staggerLengths,
   //staggerType, clusters don't support stagger types yet
-} : StandardSwatchConfig, {
-  stitchCount
-} : ClusterConfiguration) : Array<Array<Array<Color>>>{
+} : StandardSwatchConfig, clusterConfig : ClusterConfiguration) : Array<Array<Array<Color>>>{
   //Variable renames, deal with this later
   const clustersPerRow = stitchesPerRow;
-  const stitchesPerCluster = stitchCount;
+  const stitchesPerCluster = clusterConfig.stitchCount;
 
   const flattenedColorSequence = flatColorSequenceArray(colorSequence)
 
@@ -94,10 +92,20 @@ export function clusteredSwatchMatrix({
   let startingIndex = colorShift;
   for(let i = 0; i < numberOfRows; i++) {
     const clustersInThisRow = (staggerLengths && i % 2 === 0) ? clustersPerRow + 1 : clustersPerRow;
-    const rowOutput = [] as Array<Array<Color>>
+    const rowOutput = [] as Array<Array<Color>>;
+    if(clusterConfig.prepend){
+      const nextSlice = circularSlice(flattenedColorSequence, startingIndex, 1) as Array<Color>
+      startingIndex += 1
+      rowOutput.push(nextSlice)
+    }
     for (let j = 0; j < clustersInThisRow; j++) {
       const nextSlice = circularSlice(flattenedColorSequence, startingIndex, stitchesPerCluster) as Array<Color>
       startingIndex += stitchesPerCluster
+      rowOutput.push(nextSlice)
+    }
+    if(clusterConfig.append){
+      const nextSlice = circularSlice(flattenedColorSequence, startingIndex, 1) as Array<Color>
+      startingIndex += 1
       rowOutput.push(nextSlice)
     }
 

--- a/src/swatchHelpers.ts
+++ b/src/swatchHelpers.ts
@@ -79,7 +79,7 @@ export function clusteredSwatchMatrix({
   stitchesPerRow,
   numberOfRows,
   colorShift,
-  staggerLengths,
+  //staggerLengths, clusters don't support staggering yet
   //staggerType, clusters don't support stagger types yet
 } : StandardSwatchConfig, clusterConfig : ClusterConfiguration) : Array<Array<Array<Color>>>{
   //Variable renames, deal with this later
@@ -91,7 +91,7 @@ export function clusteredSwatchMatrix({
   const wholeOutput = [] as Array<Array<Array<Color>>>
   let startingIndex = colorShift;
   for(let i = 0; i < numberOfRows; i++) {
-    const clustersInThisRow = (staggerLengths && i % 2 === 0) ? clustersPerRow + 1 : clustersPerRow;
+    const clustersInThisRow = clustersPerRow;
     const rowOutput = [] as Array<Array<Color>>;
     if(clusterConfig.prepend){
       const nextSlice = circularSlice(flattenedColorSequence, startingIndex, 1) as Array<Color>

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,3 +44,9 @@ export type Colorway = {
 }
 
 export type ColorwayRecord = Record<string, DeepReadonly<Colorway>>
+
+export type ClusterConfiguration = {
+    stitchCount: number,
+    prepend?: boolean ,
+    append?: boolean,
+}


### PR DESCRIPTION
* Before this refactor, clustered swatches did not support staggering logic so this does not support that either
* Make logic in Swatch.tsx more straightforward (I don't need extra components to hold the logic when the logic is in a helper method instead)
* Removed unused method
* Verified visual diff on preview page between prod and local
* Verified visual diff on sunflower page between prod and local
* Verified functionality on doodle page between prod and local
* Linty fresh

Note: I didn't write the same rigorous tests as I did in the other swatchMatrix method. Part of that was because I overdid it on the other method, part of that was because there was a bit less logic in here, also there was more test coverage in Swatch.tsx I think.