### PR TITLE
Swatch info popover

### DIFF
--- a/src/SwatchInfoPopover.scss
+++ b/src/SwatchInfoPopover.scss
@@ -2,4 +2,17 @@
   position: fixed;
   top: 0;
   right: 0;
+  background-color: rgba(256,256,256,85%);
+  padding: 20px;
+  .info-heading {
+    &.clickable-info-heading {
+      cursor: pointer;
+    }
+    .icon {
+      cursor: pointer;
+      padding: 0 10px;
+    }
+    display: flex;
+    justify-content: flex-end;
+  }
 }

--- a/src/SwatchInfoPopover.scss
+++ b/src/SwatchInfoPopover.scss
@@ -1,0 +1,5 @@
+.swatch-info-popover{
+  position: fixed;
+  top: 0;
+  right: 0;
+}

--- a/src/SwatchInfoPopover.tsx
+++ b/src/SwatchInfoPopover.tsx
@@ -1,20 +1,47 @@
+import { useState } from "react";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons'
 import ColorSequenceInfo from './ColorSequenceInfo'
 import { totalColorSequenceLength } from './colorSequenceHelpers'
-import { StaggerType, SwatchConfig } from './types'
+//import { StaggerType, SwatchConfig } from './types'
+import { SwatchConfig } from './types'
 import './SwatchInfoPopover.scss'
 
-function SwatchInfoPopover({swatchConfig, staggerType}  : {
+/*function SwatchInfoPopover({swatchConfig, staggerType}  : {*/
+function SwatchInfoPopover({swatchConfig}  : {
   swatchConfig: SwatchConfig,
-  staggerType?: StaggerType,
+  /*staggerType?: StaggerType,*/
 }) {
+  const [displayInfo, setDisplayInfo] = useState(false);
+
   const numStitches = swatchConfig.stitchesPerRow * swatchConfig.numberOfRows
   const numColorSequences = numStitches/totalColorSequenceLength(swatchConfig.colorSequence)
 
   return <div className="swatch-info-popover">
-    <ColorSequenceInfo colorSequence={swatchConfig.colorSequence} colorShift={swatchConfig.colorShift}/>
-    <p>In this swatch:</p>
-    <pre>Number of stitches/clusters displayed (might be wrong with a stagger type): {numStitches}</pre>
-    <pre>Number of {swatchConfig.colorSequence.length}-color color sequences displayed: {numColorSequences.toFixed(1)}</pre>
+    { displayInfo ? (
+      <div>
+        <div className="info-heading">
+          <span className="icon" onClick={() => setDisplayInfo(false)} >
+            <FontAwesomeIcon icon={faXmark}/>
+          </span>
+        </div>
+        <ColorSequenceInfo colorSequence={swatchConfig.colorSequence} colorShift={swatchConfig.colorShift}/>
+        <p>In this swatch:</p>
+        <pre>Number of stitches/clusters displayed (might be wrong with a stagger type): {numStitches}</pre>
+        <pre>Number of {swatchConfig.colorSequence.length}-color color sequences displayed: {numColorSequences.toFixed(1)}</pre>
+      </div>
+    ) : (
+      <div>
+        <div className="info-heading clickable-info-heading" onClick={() => setDisplayInfo(true)} >
+          <div>
+            Show swatch info
+          </div>
+          <div className="icon">
+            <FontAwesomeIcon icon={faPlus}/>
+          </div>
+        </div>
+      </div>
+    ) }
   </div>
 }
 

--- a/src/SwatchInfoPopover.tsx
+++ b/src/SwatchInfoPopover.tsx
@@ -1,0 +1,21 @@
+import ColorSequenceInfo from './ColorSequenceInfo'
+import { totalColorSequenceLength } from './colorSequenceHelpers'
+import { StaggerType, SwatchConfig } from './types'
+import './SwatchInfoPopover.scss'
+
+function SwatchInfoPopover({swatchConfig, staggerType}  : {
+  swatchConfig: SwatchConfig,
+  staggerType?: StaggerType,
+}) {
+  const numStitches = swatchConfig.stitchesPerRow * swatchConfig.numberOfRows
+  const numColorSequences = numStitches/totalColorSequenceLength(swatchConfig.colorSequence)
+
+  return <div className="swatch-info-popover">
+    <ColorSequenceInfo colorSequence={swatchConfig.colorSequence} colorShift={swatchConfig.colorShift}/>
+    <p>In this swatch:</p>
+    <pre>Number of stitches/clusters displayed (might be wrong with a stagger type): {numStitches}</pre>
+    <pre>Number of {swatchConfig.colorSequence.length}-color color sequences displayed: {numColorSequences.toFixed(1)}</pre>
+  </div>
+}
+
+export default SwatchInfoPopover;

--- a/src/projects/Experimental.tsx
+++ b/src/projects/Experimental.tsx
@@ -2,9 +2,8 @@ import SwatchWithForm from '../SwatchWithForm';
 import { StitchPattern, Color, StaggerType } from '../types'
 import { useSwatchConfigStateFromURLParams, useEffectToUpdateURLParamsFromSwatchConfig } from '../URLSwatchParams';
 import { useState } from "react";
-import ColorSequenceInfo from '../ColorSequenceInfo'
+import SwatchInfoPopover from '../SwatchInfoPopover'
 import DropdownInput from '../inputs/Dropdown';
-import { totalColorSequenceLength } from '../colorSequenceHelpers'
 
 const red = "#ff001d" as Color;
 const cream = "#fcf7eb" as Color;
@@ -38,9 +37,6 @@ function Experimental() {
 
   useEffectToUpdateURLParamsFromSwatchConfig(swatchConfig, setSearchParams)
 
-  const numStitches = swatchConfig.stitchesPerRow * swatchConfig.numberOfRows
-  const numColorSequences = numStitches/totalColorSequenceLength(swatchConfig.colorSequence)
-
   return (
     <div>
       <p>This is an experimental page. It might change at anytime and URLs can break.</p>
@@ -58,10 +54,6 @@ function Experimental() {
         className='wide-first-column'
       >
         <fieldset>
-          <ColorSequenceInfo colorSequence={swatchConfig.colorSequence} colorShift={swatchConfig.colorShift}/>
-          <p>In this swatch:</p>
-          <pre>Number of stitches/clusters displayed (might be wrong with a stagger type): {numStitches}</pre>
-          <pre>Number of {swatchConfig.colorSequence.length}-color color sequences displayed: {numColorSequences.toFixed(1)}</pre>
           <DropdownInput
             label="Row alternating technique:"
             name="staggerType"
@@ -82,6 +74,10 @@ function Experimental() {
         setSwatchConfig={setSwatchConfig}
         staggerType={staggerType}
         showExperimentalFeatures={true}
+      />
+      <SwatchInfoPopover
+        swatchConfig={swatchConfig}
+        staggerType={staggerType}
       />
     </div>
   );

--- a/src/projects/Experimental.tsx
+++ b/src/projects/Experimental.tsx
@@ -51,7 +51,6 @@ function Experimental() {
         onSubmit={(e) => {
           e.preventDefault();
         }}
-        className='wide-first-column'
       >
         <fieldset>
           <DropdownInput
@@ -77,7 +76,7 @@ function Experimental() {
       />
       <SwatchInfoPopover
         swatchConfig={swatchConfig}
-        staggerType={staggerType}
+        //staggerType={staggerType}
       />
     </div>
   );


### PR DESCRIPTION
Move extra swatch info on experimental page into a popover thing that sits above the page
<img width="959" alt="Screenshot 2025-01-24 at 3 14 56 PM" src="https://github.com/user-attachments/assets/e291257e-6cb4-4110-8ee8-a6a58f070bbb" />
<img width="975" alt="Screenshot 2025-01-24 at 3 15 13 PM" src="https://github.com/user-attachments/assets/beca203a-5e48-43a3-bde7-788ad632dff7" />
