### PR TITLE
Convert StaggerType to an enum

### DIFF
--- a/src/Swatch.test.tsx
+++ b/src/Swatch.test.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { StitchPattern, SwatchConfig, ColorSequenceArray } from './types'
+import { StitchPattern, SwatchConfig, ColorSequenceArray, StaggerType } from './types'
 import Swatch from './Swatch'
 
 const basicSwatchConfig = {
@@ -83,7 +83,7 @@ describe('Swatch', () => {
               colorShift={1}
               numberOfRows={2}
               staggerLengths={true}
-              staggerType="colorStretched"
+              staggerType={StaggerType.colorStretched}
             />
             <Swatch
               colorSequence={[
@@ -194,7 +194,7 @@ describe('Swatch', () => {
                 {color: '#f00', length: 3},
                 {color: '#0f0', length: 2},
               ]}
-              staggerType='colorSwallowed'
+              staggerType={StaggerType.colorSwallowed}
               stitchPattern={StitchPattern.moss}
               stitchesPerRow={5}
               numberOfRows={4}
@@ -343,7 +343,7 @@ describe('Swatch', () => {
               stitchesPerRow={5}
               numberOfRows={4}
               staggerLengths={true}
-              staggerType={'colorSwallowed'}
+              staggerType={StaggerType.colorSwallowed}
             />
           )
 
@@ -384,7 +384,7 @@ describe('Swatch', () => {
               {color: '#900', length: 1},
             ]}
             stitchPattern={StitchPattern.moss}
-            staggerType='colorStretched'
+            staggerType={StaggerType.colorStretched}
             stitchesPerRow={5}
             numberOfRows={4}
             staggerLengths={true}

--- a/src/Swatch.tsx
+++ b/src/Swatch.tsx
@@ -42,7 +42,7 @@ function Stitch ({color} : { color: Color}) {
 }
 
 function Swatch(
-  { colorSequence, stitchesPerRow, stitchPattern, numberOfRows = 40, colorShift = 0, staggerLengths = false, staggerType = 'normal', className}
+  { colorSequence, stitchesPerRow, stitchPattern, numberOfRows = 40, colorShift = 0, staggerLengths = false, staggerType = StaggerType.normal, className}
   : {
     colorSequence: ColorSequenceArray,
     stitchesPerRow: number,

--- a/src/projects/DoloresParkTote.tsx
+++ b/src/projects/DoloresParkTote.tsx
@@ -13,6 +13,7 @@ function DoloresParkTote() {
   const [staggerType, setStaggerType] = useState(StaggerType.colorStretched)
 
   const setStaggerTypeFromDropdown = (newStaggerType: string) => {
+    //TODO: write some tests for this dropdown. The typecasting might be cargo culted and fail silently one day
     setStaggerType(newStaggerType as StaggerType)
   }
 
@@ -99,8 +100,8 @@ function DoloresParkTote() {
             value={staggerType}
             setValue={setStaggerTypeFromDropdown}
             items={[
-              {label: 'Color stretching', value: 'colorStretched'},
-              {label: 'Color swallowing', value: 'colorSwallowed'},
+              {label: 'Color stretching', value: StaggerType.colorStretched},
+              {label: 'Color swallowing', value: StaggerType.colorSwallowed},
             ]}
           />
           <label>

--- a/src/projects/DoloresParkTote.tsx
+++ b/src/projects/DoloresParkTote.tsx
@@ -10,7 +10,7 @@ function DoloresParkTote() {
   const initialColorway = dunaColorways[defaultDunaColorwayId]
   const initialColorSequence = duplicateColorSequenceArray(initialColorway.colorSequence)
   const [selectedColorway, setSelectedColorway] = useState(defaultDunaColorwayId)
-  const [staggerType, setStaggerType] = useState('colorStretched' as StaggerType)
+  const [staggerType, setStaggerType] = useState(StaggerType.colorStretched)
 
   const setStaggerTypeFromDropdown = (newStaggerType: string) => {
     setStaggerType(newStaggerType as StaggerType)

--- a/src/projects/Experimental.tsx
+++ b/src/projects/Experimental.tsx
@@ -33,6 +33,7 @@ function Experimental() {
   const [staggerType, setStaggerType] = useState(StaggerType.normal)
 
   const setStaggerTypeFromDropdown = (newStaggerType: string) => {
+    //TODO: write some tests for this dropdown. The typecasting might be cargo culted and fail silently one day
     setStaggerType(newStaggerType as StaggerType)
   }
 
@@ -70,9 +71,9 @@ function Experimental() {
             setValue={setStaggerTypeFromDropdown}
             withTooltip={true}
             items={[
-              {label: 'Display odd rows and even rows with different lengths', value: 'normal'},
-              {label: 'Color stretching (increasing tension)', value: 'colorStretched'},
-              {label: 'Color swallowing (loosening tension)', value: 'colorSwallowed'},
+              {label: 'Display odd rows and even rows with different lengths', value: StaggerType.normal},
+              {label: 'Color stretching (increasing tension)', value: StaggerType.colorStretched},
+              {label: 'Color swallowing (loosening tension)', value: StaggerType.colorSwallowed},
             ]}
           />
         </fieldset>

--- a/src/projects/Experimental.tsx
+++ b/src/projects/Experimental.tsx
@@ -30,7 +30,7 @@ function Experimental() {
 
   const { swatchConfig, setSwatchConfig, setSearchParams} = useSwatchConfigStateFromURLParams(defaultSwatchConfig);
 
-  const [staggerType, setStaggerType] = useState('normal' as StaggerType)
+  const [staggerType, setStaggerType] = useState(StaggerType.normal)
 
   const setStaggerTypeFromDropdown = (newStaggerType: string) => {
     setStaggerType(newStaggerType as StaggerType)

--- a/src/projects/Preview.tsx
+++ b/src/projects/Preview.tsx
@@ -1,5 +1,5 @@
 import Swatch from '../Swatch'
-import { StitchPattern, ColorSequenceArray, Color } from '../types'
+import { StitchPattern, ColorSequenceArray, Color, StaggerType } from '../types'
 
 const yellow : Color = "#faf619";
 const red : Color = "#fa1933";
@@ -47,12 +47,12 @@ export default function Preview() {
       <h4>Testing color stretching and swallowing</h4>
       <h5>unstyled normal, swallowed, stretched</h5>
       <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} staggerLengths={true} numberOfRows={8}/>
-      <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} staggerLengths={true} staggerType={'colorSwallowed'} numberOfRows={8}/>
-      <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} staggerLengths={true} staggerType={'colorStretched'} numberOfRows={8}/>
+      <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} staggerLengths={true} staggerType={StaggerType.colorSwallowed} numberOfRows={8}/>
+      <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} staggerLengths={true} staggerType={StaggerType.colorStretched} numberOfRows={8}/>
       <h5>moss normal, swallowed, stretched</h5>
       <Swatch {...basicProps} stitchPattern={StitchPattern.moss} staggerLengths={true} numberOfRows={8}/>
-      <Swatch {...basicProps} stitchPattern={StitchPattern.moss} staggerLengths={true} staggerType={'colorSwallowed'} numberOfRows={8}/>
-      <Swatch {...basicProps} stitchPattern={StitchPattern.moss} staggerLengths={true} staggerType={'colorStretched'} numberOfRows={8}/>
+      <Swatch {...basicProps} stitchPattern={StitchPattern.moss} staggerLengths={true} staggerType={StaggerType.colorSwallowed} numberOfRows={8}/>
+      <Swatch {...basicProps} stitchPattern={StitchPattern.moss} staggerLengths={true} staggerType={StaggerType.colorStretched} numberOfRows={8}/>
 
       <StitchPatternPreview stitchPattern={StitchPattern.unstyled} title="unstyled stitch pattern"/>
       <StitchPatternPreview stitchPattern={StitchPattern.stacked}/>

--- a/src/projects/SwimLesson.tsx
+++ b/src/projects/SwimLesson.tsx
@@ -15,6 +15,7 @@ function SwimLesson() {
   const [staggerType, setStaggerType] = useState(StaggerType.colorStretched)
 
   const setStaggerTypeFromDropdown = (newStaggerType: string) => {
+    //TODO: write some tests for this dropdown. The typecasting might be cargo culted and fail silently one day
     setStaggerType(newStaggerType as StaggerType)
   }
 
@@ -87,8 +88,8 @@ function SwimLesson() {
             value={staggerType}
             setValue={setStaggerTypeFromDropdown}
             items={[
-              {label: 'Color stretching', value: 'colorStretched'},
-              {label: 'Color swallowing', value: 'colorSwallowed'},
+              {label: 'Color stretching', value: StaggerType.colorStretched},
+              {label: 'Color swallowing', value: StaggerType.colorSwallowed},
             ]}
           />
           <label>

--- a/src/projects/SwimLesson.tsx
+++ b/src/projects/SwimLesson.tsx
@@ -12,7 +12,7 @@ function SwimLesson() {
     { color: "#d6dfd7", length: 8 },
     { color: "#0e7a42", length: 6 }
   ] as ColorSequenceArray
-  const [staggerType, setStaggerType] = useState('colorStretched' as StaggerType)
+  const [staggerType, setStaggerType] = useState(StaggerType.colorStretched)
 
   const setStaggerTypeFromDropdown = (newStaggerType: string) => {
     setStaggerType(newStaggerType as StaggerType)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 import { DeepReadonly } from 'ts-essentials'
 
-// consider making this an enum later. I can say `const foo = 'whatever' as StaggerType` right now.
-export type StaggerType = 'colorStretched' | 'colorSwallowed' | 'normal'
+export enum StaggerType {
+  colorStretched = 'colorStretched',
+  colorSwallowed = 'colorSwallowed',
+  normal = 'normal'
+}
 
 export enum StitchPattern {
   unstyled = "unstyled",


### PR DESCRIPTION
Note: In my dropdowns (on /experimental, /dolores-park-tote, and /swim-lesson) I still explicitly set strings for the dropdown values and then cast the result to the StaggerType enum. I don't know how I feel about this, but everything works and passes the linter. I think a "more correct" version would be much uglier and harder to read code-wise.