### PR TITLE
Stagger longest color

### DIFF
--- a/src/Form.scss
+++ b/src/Form.scss
@@ -29,6 +29,10 @@ fieldset {
     }
   }
 
+  .highlighted {
+    background-color: #eeff77;
+  }
+
   .input-group, .color-segment {
     display: flex;
     align-items: center;

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -4,7 +4,7 @@ import TogglableColorPicker from './inputs/TogglableColorPicker'
 import IntegerInput from './inputs/Integer'
 import { Color, SwatchConfig, StaggerType } from './types'
 import { getRandomNotWhiteColor } from './colorHelpers'
-import { totalColorSequenceLength, presetPickerColors } from './colorSequenceHelpers'
+import { totalColorSequenceLength, presetPickerColors, firstLongestColor } from './colorSequenceHelpers'
 import { mod } from './numberHelpers'
 
 type FormValue = keyof(SwatchConfig)
@@ -79,6 +79,9 @@ function Form(
       return "This will stretch the length of the color that ends an even row/starts an odd row.\n\nThat is, if you normally have 5 stitches of a color, this will make it 6 at that transition point."
     } else if (staggerType === "colorSwallowed") {
       return "This will contract the length of the color that starts an odd row.\n\nThat is, if you normally have 5 stitches of a color, this will make it 4 at that transition point."
+    } else if (staggerType === "staggerLongestColor") {
+      const longestColorLength = firstLongestColor(colorSequence).colorInSequence.length
+      return `This will adjust the length of the longest color in your swatch every other time you encounter it.\n\nThe highlighted color will alternate between ${longestColorLength} and ${longestColorLength + 1} stitches long`
     } else {
       return `This will make odd rows of your project one stitch longer than the even rows. \n\nWith your current settings, odd rows will be ${stitchesPerRow+1} stitches long.`
     }
@@ -89,10 +92,14 @@ function Form(
       return "Stretch Colors at row boundary"
     } else if (staggerType === "colorSwallowed") {
       return "Swallow Colors at row boundary"
+    } else if (staggerType === "staggerLongestColor") {
+      return "Stagger length of longest color"
     } else {
       return "Alternate Row Lengths"
     }
   }
+
+  const longestColorIndex = firstLongestColor(colorSequence).index
 
   return (
     <form
@@ -102,8 +109,12 @@ function Form(
       className={className}
     >
       <fieldset className='color-fields'>
-        {colorSequence.map((obj, index) => (
-          <div className='color-segment' key={index + 1}>
+        {colorSequence.map((obj, index) => {
+          const classNames = [
+            'color-segment',
+            index === longestColorIndex && staggerType === StaggerType.staggerLongestColor ? 'highlighted' : ''
+          ]
+          return ( <div className={classNames.join(' ')} key={index + 1}>
             <label>
               Color {(index + 1)}:
             </label>
@@ -122,7 +133,8 @@ function Form(
             />
             <button type="button" onClick={() => removeColorFromSequence(index)}>Remove color</button>
           </div>
-        ))}
+          )
+        })}
         <div className="buttons">
           <button type="button" onClick={addColorToSequence}>Add a color</button>
           { showExperimentalFeatures ? <button type="button" onClick={duplicateColorSequence}>Double the colors</button> : ''}

--- a/src/Swatch.scss
+++ b/src/Swatch.scss
@@ -52,12 +52,12 @@ version of preview. Hopefully there will be a test of this diff at some point*/
 
 /*Basic layout swatches: moss, hdc, granny, shell, v-stitch*/
 @mixin interwovenStitch($stitchHeight, $stitchWidth, $spacing, $overlapRatio) {
-  &.staggered.normal {
+  &.staggered.alternateRowLengths {
     .crow:nth-child(2n) {
       margin: 0 $stitchWidth + $spacing;
     }
   }
-  &:not(.staggered.normal) {
+  &:not(.staggered.alternateRowLengths) {
     .crow:nth-child(2n) {
       margin-right: $stitchWidth + $spacing;
     }
@@ -76,7 +76,7 @@ version of preview. Hopefully there will be a test of this diff at some point*/
     margin-top: $spacing;
     margin-bottom: -1 * $overlapRatio * $stitchHeight;
   }
-  &.numbered:not(.staggered.normal) {
+  &.numbered:not(.staggered.alternateRowLengths) {
     .crow:nth-child(2n + 1) {
       &::before {
         margin-left: -1*$stitchWidth - 15px;

--- a/src/Swatch.scss
+++ b/src/Swatch.scss
@@ -52,12 +52,12 @@ version of preview. Hopefully there will be a test of this diff at some point*/
 
 /*Basic layout swatches: moss, hdc, granny, shell, v-stitch*/
 @mixin interwovenStitch($stitchHeight, $stitchWidth, $spacing, $overlapRatio) {
-  &.staggered:not(.colorSwallowed):not(.colorStretched) {
+  &.staggered.normal {
     .crow:nth-child(2n) {
       margin: 0 $stitchWidth + $spacing;
     }
   }
-  &:not(.staggered), &.colorSwallowed, &.colorStretched {
+  &:not(.staggered.normal) {
     .crow:nth-child(2n) {
       margin-right: $stitchWidth + $spacing;
     }
@@ -76,7 +76,7 @@ version of preview. Hopefully there will be a test of this diff at some point*/
     margin-top: $spacing;
     margin-bottom: -1 * $overlapRatio * $stitchHeight;
   }
-  &.numbered:not(.staggered), &.numbered.colorSwallowed, &.numbered.colorStretched {
+  &.numbered:not(.staggered.normal) {
     .crow:nth-child(2n + 1) {
       &::before {
         margin-left: -1*$stitchWidth - 15px;

--- a/src/Swatch.tsx
+++ b/src/Swatch.tsx
@@ -42,7 +42,7 @@ function Stitch ({color} : { color: Color}) {
 }
 
 function Swatch(
-  { colorSequence, stitchesPerRow, stitchPattern, numberOfRows = 40, colorShift = 0, staggerLengths = false, staggerType = StaggerType.normal, className}
+  { colorSequence, stitchesPerRow, stitchPattern, numberOfRows = 40, colorShift = 0, staggerLengths = false, staggerType = StaggerType.alternateRowLengths, className}
   : {
     colorSequence: ColorSequenceArray,
     stitchesPerRow: number,

--- a/src/colorSequenceHelpers.test.ts
+++ b/src/colorSequenceHelpers.test.ts
@@ -5,6 +5,7 @@ import {
   totalColorSequenceLength,
   matchColorwayToColorSequence,
   presetPickerColors,
+  firstLongestColor,
 } from './colorSequenceHelpers'
 import { Color, ColorSequenceArray, ColorwayRecord } from './types'
 
@@ -100,6 +101,18 @@ describe('totalColorSequenceLength', () => {
       {color: "#00f", length: 4}
     ] as ColorSequenceArray
     expect(totalColorSequenceLength(config)).toEqual(9)
+  })
+})
+
+describe('firstLongestColor', () => {
+  it('returns the first longest color in the color sequence array as well as its index', () => {
+    const config = [
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 4},
+      {color: "#ccc", length: 4},
+      {color: "#ddd", length: 3},
+    ] as ColorSequenceArray
+    expect(firstLongestColor(config)).toEqual({colorInSequence: {color: "#bbb", length: 4}, index: 1})
   })
 })
 

--- a/src/colorSequenceHelpers.test.ts
+++ b/src/colorSequenceHelpers.test.ts
@@ -6,6 +6,7 @@ import {
   matchColorwayToColorSequence,
   presetPickerColors,
   firstLongestColor,
+  staggerLongestColor,
 } from './colorSequenceHelpers'
 import { Color, ColorSequenceArray, ColorwayRecord } from './types'
 
@@ -113,6 +114,33 @@ describe('firstLongestColor', () => {
       {color: "#ddd", length: 3},
     ] as ColorSequenceArray
     expect(firstLongestColor(config)).toEqual({colorInSequence: {color: "#bbb", length: 4}, index: 1})
+  })
+})
+
+describe('staggerLongestColor', () => {
+  it('staggers the first longest color in the color sequence array without changing input', () => {
+    const config = [
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 4},
+      {color: "#ccc", length: 4},
+      {color: "#ddd", length: 3},
+    ] as ColorSequenceArray
+    expect(staggerLongestColor(config)).toEqual([
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 4},
+      {color: "#ccc", length: 4},
+      {color: "#ddd", length: 3},
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 5},
+      {color: "#ccc", length: 4},
+      {color: "#ddd", length: 3},
+    ])
+    expect(config).toEqual([
+      {color: "#aaa", length: 2},
+      {color: "#bbb", length: 4},
+      {color: "#ccc", length: 4},
+      {color: "#ddd", length: 3},
+    ])
   })
 })
 

--- a/src/colorSequenceHelpers.ts
+++ b/src/colorSequenceHelpers.ts
@@ -30,6 +30,14 @@ export function totalColorSequenceLength(colorSequence : ColorSequenceArray) : n
   return result;
 }
 
+export function firstLongestColor(colorSequence : ColorSequenceArray) : {colorInSequence: ColorInSequence, index: number} {
+  return colorSequence.reduce(
+    (saved, currColor, currIndex) => 
+    saved.colorInSequence.length >= currColor.length ? saved : {colorInSequence: currColor, index: currIndex},
+    {colorInSequence: colorSequence[0], index: 0}
+  )
+}
+
 export function duplicateColorSequenceArray(colorSequence : DeepReadonly<ColorSequenceArray> | ColorSequenceArray) : ColorSequenceArray {
   return colorSequence.map((c) => ({...c}))
 }

--- a/src/colorSequenceHelpers.ts
+++ b/src/colorSequenceHelpers.ts
@@ -38,6 +38,13 @@ export function firstLongestColor(colorSequence : ColorSequenceArray) : {colorIn
   )
 }
 
+export function staggerLongestColor(origColorSequence : ColorSequenceArray) : ColorSequenceArray {
+  const staggeredColorSequence = duplicateColorSequenceArray(origColorSequence)
+  const newLongestColor = firstLongestColor(staggeredColorSequence)
+  newLongestColor.colorInSequence.length += 1
+  return [...origColorSequence, ...staggeredColorSequence]
+}
+
 export function duplicateColorSequenceArray(colorSequence : DeepReadonly<ColorSequenceArray> | ColorSequenceArray) : ColorSequenceArray {
   return colorSequence.map((c) => ({...c}))
 }

--- a/src/projects/Experimental.tsx
+++ b/src/projects/Experimental.tsx
@@ -29,7 +29,7 @@ function Experimental() {
 
   const { swatchConfig, setSwatchConfig, setSearchParams} = useSwatchConfigStateFromURLParams(defaultSwatchConfig);
 
-  const [staggerType, setStaggerType] = useState(StaggerType.normal)
+  const [staggerType, setStaggerType] = useState(StaggerType.alternateRowLengths)
 
   const setStaggerTypeFromDropdown = (newStaggerType: string) => {
     //TODO: write some tests for this dropdown. The typecasting might be cargo culted and fail silently one day
@@ -62,9 +62,10 @@ function Experimental() {
             setValue={setStaggerTypeFromDropdown}
             withTooltip={true}
             items={[
-              {label: 'Display odd rows and even rows with different lengths', value: StaggerType.normal},
+              {label: 'Display odd rows and even rows with different lengths', value: StaggerType.alternateRowLengths},
               {label: 'Color stretching (increasing tension)', value: StaggerType.colorStretched},
               {label: 'Color swallowing (loosening tension)', value: StaggerType.colorSwallowed},
+              {label: 'Adjust length of longest color', value: StaggerType.staggerLongestColor},
             ]}
           />
         </fieldset>

--- a/src/projects/Preview.tsx
+++ b/src/projects/Preview.tsx
@@ -45,11 +45,11 @@ export default function Preview() {
       <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} numberOfRows={8}/>
       <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} numberOfRows={8} colorShift={1}/>
       <h4>Testing color stretching and swallowing</h4>
-      <h5>unstyled normal, swallowed, stretched</h5>
+      <h5>unstyled default, swallowed, stretched</h5>
       <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} staggerLengths={true} numberOfRows={8}/>
       <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} staggerLengths={true} staggerType={StaggerType.colorSwallowed} numberOfRows={8}/>
       <Swatch {...basicProps} stitchPattern={StitchPattern.unstyled} staggerLengths={true} staggerType={StaggerType.colorStretched} numberOfRows={8}/>
-      <h5>moss normal, swallowed, stretched</h5>
+      <h5>moss default, swallowed, stretched</h5>
       <Swatch {...basicProps} stitchPattern={StitchPattern.moss} staggerLengths={true} numberOfRows={8}/>
       <Swatch {...basicProps} stitchPattern={StitchPattern.moss} staggerLengths={true} staggerType={StaggerType.colorSwallowed} numberOfRows={8}/>
       <Swatch {...basicProps} stitchPattern={StitchPattern.moss} staggerLengths={true} staggerType={StaggerType.colorStretched} numberOfRows={8}/>

--- a/src/projects/SwimLessonDarkly.tsx
+++ b/src/projects/SwimLessonDarkly.tsx
@@ -1,7 +1,7 @@
 import './SwimLessonDarkly.scss';
 import SwatchWithForm from '../SwatchWithForm';
 import Swatch from '../Swatch';
-import { StitchPattern, ColorSequenceArray, StaggerType } from '../types'
+import { StitchPattern, StaggerType } from '../types'
 import { Fragment, useState, useEffect } from "react";
 import DropdownInput from '../inputs/Dropdown';
 import { aSkeinerDarklyColorways, defaultASkeinerDarklyColorwayId } from '../colorways';
@@ -12,7 +12,7 @@ function SwimLessonDarkly() {
   const initialColorway = aSkeinerDarklyColorways[defaultASkeinerDarklyColorwayId]
   const initialColorSequence = duplicateColorSequenceArray(initialColorway.colorSequence)
   const [selectedColorway, setSelectedColorway] = useState(defaultASkeinerDarklyColorwayId)
-  const [staggerType, setStaggerType] = useState(StaggerType.colorStretched)
+  const [staggerType, setStaggerType] = useState(StaggerType.staggerLongestColor)
 
   const setStaggerTypeFromDropdown = (newStaggerType: string) => {
     //TODO: write some tests for this dropdown. The typecasting might be cargo culted and fail silently one day
@@ -114,6 +114,7 @@ function SwimLessonDarkly() {
             value={staggerType}
             setValue={setStaggerTypeFromDropdown}
             items={[
+              {label: 'Alternate Lengths of Longest Color', value: StaggerType.staggerLongestColor},
               {label: 'Color stretching', value: StaggerType.colorStretched},
               {label: 'Color swallowing', value: StaggerType.colorSwallowed},
             ]}

--- a/src/swatchHelpers.test.ts
+++ b/src/swatchHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ColorSequenceArray } from './types'
+import { ColorSequenceArray, StaggerType } from './types'
 import {
   swatchMatrix,
   swatchMatrixWithReversedEvenRows,
@@ -20,7 +20,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
         ["#eee","#aaa","#bbb","#ccc"],
@@ -40,7 +40,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         [],
         [],
@@ -60,7 +60,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 0,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([])
   })
   it("doesn't choke on zero length colors", () => {
@@ -76,7 +76,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#aaa","#ccc","#ddd"],
         ["#eee","#aaa","#ccc"],
@@ -94,7 +94,7 @@ describe('swatchMatrix', () => {
       numberOfRows: 4,
       staggerLengths: false,
       colorShift: 0,
-      staggerType: 'normal'
+      staggerType: StaggerType.normal
     })).toEqual([
       ["#000","#000","#000","#111"],
       ["#111","#222","#222","#222"],
@@ -115,7 +115,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
@@ -135,7 +135,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 3,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#ddd","#eee","#aaa","#bbb"],
         ["#ccc","#ddd","#eee","#aaa"],
@@ -155,7 +155,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         colorShift: 0,
         staggerLengths: true,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
         ["#aaa","#bbb","#ccc","#ddd"],
@@ -175,7 +175,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 4,
         colorShift: 0,
         staggerLengths: true,
-        staggerType: 'colorSwallowed'
+        staggerType: StaggerType.colorSwallowed
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
         ["#eee","#aaa","#bbb","#ccc"],
@@ -196,7 +196,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 5,
         colorShift: 0,
         staggerLengths: true,
-        staggerType: 'colorStretched'
+        staggerType: StaggerType.colorStretched
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
         ["#eee","#aaa","#bbb","#ccc"],
@@ -221,7 +221,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
         ["#ccc","#bbb","#aaa","#eee"],
@@ -241,7 +241,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         [],
         [],
@@ -261,7 +261,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 0,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([])
   })
   it("doesn't choke on zero length colors", () => {
@@ -277,7 +277,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#aaa","#ccc","#ddd"],
         ["#ccc","#aaa","#eee"],
@@ -295,7 +295,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
       numberOfRows: 4,
       staggerLengths: false,
       colorShift: 0,
-      staggerType: 'normal'
+      staggerType: StaggerType.normal
     })).toEqual([
       ["#000","#000","#000","#111"],
       ["#222","#222","#222","#111"],
@@ -316,7 +316,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
         ["#eee","#ddd","#ccc","#bbb","#aaa"],
@@ -336,7 +336,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 3,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#ddd","#eee","#aaa","#bbb"],
         ["#aaa","#eee","#ddd","#ccc"],
@@ -356,7 +356,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         colorShift: 0,
         staggerLengths: true,
-        staggerType: 'normal'
+        staggerType: StaggerType.normal
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
         ["#ddd","#ccc","#bbb","#aaa"],
@@ -376,7 +376,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         colorShift: 0,
         staggerLengths: true,
-        staggerType: 'colorSwallowed'
+        staggerType: StaggerType.colorSwallowed
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
         ["#ccc","#bbb","#aaa","#eee"],
@@ -396,7 +396,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 5,
         colorShift: 0,
         staggerLengths: true,
-        staggerType: 'colorStretched'
+        staggerType: StaggerType.colorStretched
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
         ["#ccc","#bbb","#aaa","#eee"],

--- a/src/swatchHelpers.test.ts
+++ b/src/swatchHelpers.test.ts
@@ -162,7 +162,7 @@ describe('swatchMatrix', () => {
         ["#eee","#aaa","#bbb","#ccc","#ddd"]
       ])
   })
-  it('pretends to swallow stitches because the css removes the first stitch from odd rows', () => {
+  it('swallows stitches', () => {
     expect(
       swatchMatrix({colorSequence: [
         {color: '#aaa', length: 1},
@@ -181,6 +181,28 @@ describe('swatchMatrix', () => {
         ["#eee","#aaa","#bbb","#ccc"],
         ["#eee","#aaa","#bbb","#ccc"],
         ["#ddd","#eee","#aaa","#bbb"],
+      ])
+  })
+  it('staggers length of first longest color', () => {
+    expect(
+      swatchMatrix({colorSequence: [
+        {color: '#aaa', length: 1},
+        {color: '#bbb', length: 2},
+        {color: '#ccc', length: 1},
+        {color: '#ddd', length: 2},
+        {color: '#eee', length: 1},
+      ] as ColorSequenceArray,
+        stitchesPerRow: 4,
+        numberOfRows: 5,
+        colorShift: 0,
+        staggerLengths: true,
+        staggerType: StaggerType.staggerLongestColor
+      })).toEqual([
+        ["#aaa","#bbb","#bbb","#ccc"],
+        ["#ddd","#ddd","#eee","#aaa"],
+        ["#bbb","#bbb","#bbb","#ccc"],
+        ["#ddd","#ddd","#eee","#aaa"],
+        ["#bbb","#bbb","#ccc","#ddd"],
       ])
   })
   it('stretches stitches', () => {

--- a/src/swatchHelpers.test.ts
+++ b/src/swatchHelpers.test.ts
@@ -20,7 +20,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
         ["#eee","#aaa","#bbb","#ccc"],
@@ -40,7 +40,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         [],
         [],
@@ -60,7 +60,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 0,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([])
   })
   it("doesn't choke on zero length colors", () => {
@@ -76,7 +76,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#aaa","#ccc","#ddd"],
         ["#eee","#aaa","#ccc"],
@@ -94,7 +94,7 @@ describe('swatchMatrix', () => {
       numberOfRows: 4,
       staggerLengths: false,
       colorShift: 0,
-      staggerType: StaggerType.normal
+      staggerType: StaggerType.alternateRowLengths
     })).toEqual([
       ["#000","#000","#000","#111"],
       ["#111","#222","#222","#222"],
@@ -115,7 +115,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
@@ -135,14 +135,14 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 3,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#ddd","#eee","#aaa","#bbb"],
         ["#ccc","#ddd","#eee","#aaa"],
         ["#bbb","#ccc","#ddd","#eee"]
       ])
   })
-  it('makes odd rows have one extra color when staggerLengths is true and staggerType is normal', () => {
+  it('makes odd rows have one extra color when staggerLengths is true and staggerType is alternateRowLengths', () => {
     expect(
       swatchMatrix({colorSequence: [
         {color: '#aaa', length: 1},
@@ -155,7 +155,7 @@ describe('swatchMatrix', () => {
         numberOfRows: 3,
         colorShift: 0,
         staggerLengths: true,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
         ["#aaa","#bbb","#ccc","#ddd"],
@@ -221,7 +221,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd"],
         ["#ccc","#bbb","#aaa","#eee"],
@@ -241,7 +241,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         [],
         [],
@@ -261,7 +261,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 0,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([])
   })
   it("doesn't choke on zero length colors", () => {
@@ -277,7 +277,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#aaa","#ccc","#ddd"],
         ["#ccc","#aaa","#eee"],
@@ -295,7 +295,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
       numberOfRows: 4,
       staggerLengths: false,
       colorShift: 0,
-      staggerType: StaggerType.normal
+      staggerType: StaggerType.alternateRowLengths
     })).toEqual([
       ["#000","#000","#000","#111"],
       ["#222","#222","#222","#111"],
@@ -316,7 +316,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 0,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
         ["#eee","#ddd","#ccc","#bbb","#aaa"],
@@ -336,14 +336,14 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         staggerLengths: false,
         colorShift: 3,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#ddd","#eee","#aaa","#bbb"],
         ["#aaa","#eee","#ddd","#ccc"],
         ["#bbb","#ccc","#ddd","#eee"]
       ])
   })
-  it('makes odd rows have one extra color when staggerLengths is true and staggerType is normal', () => {
+  it('makes odd rows have one extra color when staggerLengths is true and staggerType is alternateRowLengths', () => {
     expect(
       swatchMatrixWithReversedEvenRows({colorSequence: [
         {color: '#aaa', length: 1},
@@ -356,7 +356,7 @@ describe('swatchMatrixWithReversedEvenRows', () => { //TODO this is unused, I ju
         numberOfRows: 3,
         colorShift: 0,
         staggerLengths: true,
-        staggerType: StaggerType.normal
+        staggerType: StaggerType.alternateRowLengths
       })).toEqual([
         ["#aaa","#bbb","#ccc","#ddd","#eee"],
         ["#ddd","#ccc","#bbb","#aaa"],

--- a/src/swatchHelpers.ts
+++ b/src/swatchHelpers.ts
@@ -1,4 +1,4 @@
-import { StandardSwatchConfig, Color, ClusterConfiguration } from './types'
+import { StandardSwatchConfig, Color, ClusterConfiguration, StaggerType } from './types'
 import { flatColorSequenceArray } from './colorSequenceHelpers'
 import { circularSlice } from './arrayHelpers'
 
@@ -9,24 +9,24 @@ export function swatchMatrix({
   colorShift,
   staggerLengths,
   staggerType
-} : StandardSwatchConfig & {staggerType: 'normal' | 'colorStretched' | 'colorSwallowed'}) : Array<Array<Color>>{
+} : StandardSwatchConfig & {staggerType: StaggerType}) : Array<Array<Color>>{
   const flattenedColorSequence = flatColorSequenceArray(colorSequence)
-  function staggeredWithType(typeName: 'normal' | 'colorStretched' | 'colorSwallowed') {
+  function staggeredWithType(typeName: StaggerType) {
     if (!staggerLengths) { return false }
     return staggerType === typeName
   }
   const output = [] as Array<Array<Color>>
   let startingIndex = colorShift;
   for(let i = 0; i < numberOfRows; i++) {
-    const stitchesInThisRow = (staggeredWithType('normal') && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
+    const stitchesInThisRow = (staggeredWithType(StaggerType.normal) && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
 
     const nextSlice = circularSlice(flattenedColorSequence, startingIndex, stitchesInThisRow) as Array<Color>
 
     output.push(nextSlice)
 
-    if(staggeredWithType('colorStretched') && i % 2 === 1) {
+    if(staggeredWithType(StaggerType.colorStretched) && i % 2 === 1) {
       startingIndex += stitchesInThisRow - 1
-    } else if(staggeredWithType('colorSwallowed') && i % 2 === 1) {
+    } else if(staggeredWithType(StaggerType.colorSwallowed) && i % 2 === 1) {
       startingIndex += stitchesInThisRow + 1
     } else {
       startingIndex += stitchesInThisRow
@@ -42,8 +42,8 @@ export function swatchMatrixWithReversedEvenRows({ //TODO: This is the (unused) 
   colorShift,
   staggerLengths,
   staggerType
-} : StandardSwatchConfig & {staggerType: 'normal' | 'colorStretched' | 'colorSwallowed'}) : Array<Array<Color>>{
-  function staggeredWithType(typeName: 'normal' | 'colorStretched' | 'colorSwallowed') {
+} : StandardSwatchConfig & {staggerType: StaggerType}) : Array<Array<Color>>{
+  function staggeredWithType(typeName: StaggerType) {
     if (!staggerLengths) { return false }
     return staggerType === typeName
   }
@@ -51,15 +51,15 @@ export function swatchMatrixWithReversedEvenRows({ //TODO: This is the (unused) 
   const output = [] as Array<Array<Color>>
   let startingIndex = colorShift;
   for(let i = 0; i < numberOfRows; i++) {
-    const stitchesInThisRow = (staggeredWithType('normal') && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
+    const stitchesInThisRow = (staggeredWithType(StaggerType.normal) && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
 
     const nextSlice = circularSlice(flattenedColorSequence, startingIndex, stitchesInThisRow) as Array<Color>
 
     i % 2 === 0 ? output.push(nextSlice) : output.push(nextSlice.reverse())
 
-    if(staggeredWithType('colorStretched') && i % 2 === 1) {
+    if(staggeredWithType(StaggerType.colorStretched) && i % 2 === 1) {
       startingIndex += stitchesInThisRow - 1
-    } else if(staggeredWithType('colorSwallowed') && i % 2 === 1) {
+    } else if(staggeredWithType(StaggerType.colorSwallowed) && i % 2 === 1) {
       startingIndex += stitchesInThisRow + 1
     } else {
       startingIndex += stitchesInThisRow

--- a/src/swatchHelpers.ts
+++ b/src/swatchHelpers.ts
@@ -1,5 +1,5 @@
 import { StandardSwatchConfig, Color, ClusterConfiguration, StaggerType } from './types'
-import { flatColorSequenceArray } from './colorSequenceHelpers'
+import { flatColorSequenceArray, staggerLongestColor } from './colorSequenceHelpers'
 import { circularSlice } from './arrayHelpers'
 
 export function swatchMatrix({
@@ -10,11 +10,11 @@ export function swatchMatrix({
   staggerLengths,
   staggerType
 } : StandardSwatchConfig & {staggerType: StaggerType}) : Array<Array<Color>>{
-  const flattenedColorSequence = flatColorSequenceArray(colorSequence)
   function staggeredWithType(typeName: StaggerType) {
     if (!staggerLengths) { return false }
     return staggerType === typeName
   }
+  const flattenedColorSequence = staggeredWithType(StaggerType.staggerLongestColor)? flatColorSequenceArray(staggerLongestColor(colorSequence)) : flatColorSequenceArray(colorSequence)
   const output = [] as Array<Array<Color>>
   let startingIndex = colorShift;
   for(let i = 0; i < numberOfRows; i++) {

--- a/src/swatchHelpers.ts
+++ b/src/swatchHelpers.ts
@@ -18,7 +18,7 @@ export function swatchMatrix({
   const output = [] as Array<Array<Color>>
   let startingIndex = colorShift;
   for(let i = 0; i < numberOfRows; i++) {
-    const stitchesInThisRow = (staggeredWithType(StaggerType.normal) && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
+    const stitchesInThisRow = (staggeredWithType(StaggerType.alternateRowLengths) && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
 
     const nextSlice = circularSlice(flattenedColorSequence, startingIndex, stitchesInThisRow) as Array<Color>
 
@@ -51,7 +51,7 @@ export function swatchMatrixWithReversedEvenRows({ //TODO: This is the (unused) 
   const output = [] as Array<Array<Color>>
   let startingIndex = colorShift;
   for(let i = 0; i < numberOfRows; i++) {
-    const stitchesInThisRow = (staggeredWithType(StaggerType.normal) && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
+    const stitchesInThisRow = (staggeredWithType(StaggerType.alternateRowLengths) && i % 2 === 0) ? stitchesPerRow + 1 : stitchesPerRow;
 
     const nextSlice = circularSlice(flattenedColorSequence, startingIndex, stitchesInThisRow) as Array<Color>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { DeepReadonly } from 'ts-essentials'
 export enum StaggerType {
   colorStretched = 'colorStretched',
   colorSwallowed = 'colorSwallowed',
+  staggerLongestColor = 'staggerLongestColor',
   normal = 'normal'
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export enum StaggerType {
   colorStretched = 'colorStretched',
   colorSwallowed = 'colorSwallowed',
   staggerLongestColor = 'staggerLongestColor',
-  normal = 'normal'
+  alternateRowLengths = 'alternateRowLengths'
 }
 
 export enum StitchPattern {


### PR DESCRIPTION
Add functionality to stagger the longest color in the color sequence. This makes it one stitch longer every time you encounter it.